### PR TITLE
remove empty -D flag

### DIFF
--- a/site.hxml
+++ b/site.hxml
@@ -1,5 +1,4 @@
 -cp src
 -neko bin/index.n
--D 
 -main tools.haxelib.Site
 -dce no


### PR DESCRIPTION
remove empty -D flag, which is somehow required to correctly compile the site correctly

**???**
