### PR TITLE
Fix issue #44

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -1099,7 +1099,7 @@ class Main {
 			haxelibJson = '{
   "name": "$libName",
   "url" : "$gitPath",
-  "license": "",
+  "license": "Public",
   "tags": [],
   "description": "",
   "version": "0.0.0",


### PR DESCRIPTION
Add "Public" license per default to allow install when using "haxelib git git@some-git-repo" to clone a depo without a haxelib.json file.
