### PR TITLE
Removing system ndll check

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -989,8 +989,8 @@ class Main {
 				var sysdir = ndir+"/"+Sys.systemName();
 				var is64 = neko.Lib.load("std", "sys_is64", 0)();
 				if( is64 ) sysdir += "64";
-				if( !FileSystem.exists(sysdir) )
-					throw "Library "+d.project+" version "+d.version+" does not have a neko dll for your system";
+				// if( !FileSystem.exists(sysdir) )
+				//	throw "Library "+d.project+" version "+d.version+" does not have a neko dll for your system";
 				Sys.println("-L "+pdir+"ndll/");
 			}
 			try {


### PR DESCRIPTION
This check prevents iOS/Android specific extensions from being created. It expects a Mac/LinuxWindows folder to exist when compiling for a different platform. I've simply forced haxelib to include the ndll folder if it exists.

Also, `Sys.systemName()` on line 989 returns "Linux" on OSX. I believe that's a Haxe bug however.
