### PR TITLE
Fix Invalid Operation (+) error when env vars are missing.

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -675,9 +675,15 @@ class Main {
 		var haxepath = Sys.getEnv("HAXEPATH");
 		if( haxepath != null )
 			haxepath = Path.addTrailingSlash( haxepath );
-		var config_file;
-		if( win )
-			config_file = Sys.getEnv("HOMEDRIVE") + Sys.getEnv("HOMEPATH");
+		var config_file = null;
+		if( win ) {
+			var homeDrive = Sys.getEnv("HOMEDRIVE");
+			var homePath  = Sys.getEnv("HOMEPATH");
+			if (null == homeDrive && null == homePath)
+				print("Warning: Environment variables %HOMEDRIVE% and %HOMEPATH% are missing, using %HAXEPATH%");
+			else
+				config_file = homeDrive + homePath;
+		}
 		else
 			config_file = Sys.getEnv("HOME");
 		config_file += "/.haxelib";


### PR DESCRIPTION
HOMEDRIVE/HOMEPATH are not always guaranteed to be present, if they are not, haxelib throws "Invalid Operation (+)".
http://stackoverflow.com/questions/18909393/trying-to-install-openfl-haxelib-returns-invalid-operation

As a more permanent solution to this, should we store haxelib config data in AppData? This is the correct location for it. If not, could we switch to USERPROFILE?