### PR TITLE
Default ask() to No if Eof is thrown

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -206,10 +206,15 @@ class Main {
 	function ask( question ) {
 		while( true ) {
 			Sys.print(question+" [y/n/a] ? ");
-			switch( Sys.stdin().readLine() ) {
-			case "n": return No;
-			case "y": return Yes;
-			case "a": return Always;
+			try {
+				switch( Sys.stdin().readLine() ) {
+				case "n": return No;
+				case "y": return Yes;
+				case "a": return Always;
+				}
+			} catch(e:haxe.io.Eof) {
+				Sys.println("n");
+				return No;
 			}
 		}
 		return null;


### PR DESCRIPTION
This is a minor cosmetic change for cli tools that defaults to No if the `ask` method is called and Eof is thrown.

**Previous output**

``` bash
Set <project> to version x.x.x [y/n/a] ? Eof
```

**New output**

``` bash
Set <project> to version x.x.x [y/n/a] ? n
```
