### PR TITLE
Use the last version given to path command

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -1000,7 +1000,8 @@ class Main {
 			if( p.project == prj ) {
 				if( p.version == version )
 					return;
-				throw "Library "+prj+" has two version included "+version+" and "+p.version;
+				else
+					l.remove(p); // keep the last given version only
 			}
 		var json = try File.getContent(vdir+"/"+Data.JSON) catch( e : Dynamic ) null;
 		var inf = Data.readData(json,false);


### PR DESCRIPTION
Instead of throwing an error when two versions are given I've changed `haxelib path` to use the last version. This allows dependencies to be overridden.

For example:
`haxelib path <lib>:1.2.1 <lib>:1.2.2` returns version 1.2.2
`haxelib path <lib> <lib>:1.2.1` returns version 1.2.1

An advantage of this fix is for libraries like HaxePunk and HaxeFlixel where they can set a specific version of OpenFL instead of always using the latest.
