### PR TITLE
realPath() fixed

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -881,7 +881,11 @@ class Main {
 				case "": //it is not a symlink
 					path;
 				case targetPath:
-					realPath(new Path(path).dir + "/" + targetPath);
+					if (targetPath.startsWith("/")) {
+						realPath(targetPath);
+					} else {
+						realPath(new Path(path).dir + "/" + targetPath);
+					}
 			}
 		}
 


### PR DESCRIPTION
Fix realPath() to correctly handle non-relative symlinks

For example if /usr/bin/haxelib is symlink to /usr/lib/haxe/haxelib, original realPath() will return incorrect path - /usr/bin//usr/lib/haxe/haxelib

This patch fixes it, and now realPath() will return correct path - /usr/lib/haxe/haxelib
