### PR TITLE
Download dependencies from GIT (and haxelib) with a new entry : "requirements"

### DIFF
--- a/src/tools/haxelib/Data.hx
+++ b/src/tools/haxelib/Data.hx
@@ -56,10 +56,10 @@ typedef GitPackageInfos = {
 }
 
 typedef RequirementsInfos = {
-	var name 			   : String; // Library's name
-	var type 			   : String; // Library's type (git | haxelib)
-	@:optional var version : String;
-	@:optional var package : GitPackageInfos; // Package's infos
+	var name 			      : String; // Library's name
+	var type 			      : String; // Library's type (git | haxelib)
+	@:optional var version    : String;
+	@:optional var repository : GitPackageInfos; // Package's infos
 }
 
 typedef Infos = {
@@ -234,13 +234,13 @@ class Data {
 											if ("type" == key) {
 												if (Std.string(value) != "git" || Std.string(value) != "haxelib") {
 													throw "Only git and haxelib types are allowed as requirements type";
-												} else if ("package" == key && Std.string(value) != "git") {
-													throw "Package entry can only be used by git libraries";
+												} else if ("repository" == key && Std.string(value) != "git") {
+													throw "Repository entry can only be used by git libraries";
 												}
 											}
 											else if ("version" == key) {
 												try {
-													SemVer.ofString(val);
+													SemVer.ofString(value);
 												} catch(e:String) {
 													throw 'Requirement $field has an invalid version `$value`.';
 												}
@@ -251,12 +251,13 @@ class Data {
 												switch Type.typeof(value) {
 													case TClass(String):
 														continue;
-													default: throw 'Package $f has an invalid datatype';
+													default: throw 'Repository $f has an invalid datatype';
 												}
 											}
 										default: throw "Invalid requirements structure";
 									}
 								}
+							default: throw "Invalid requirements structure";
 						}
 					}
 				default: throw "requirements must be defined as array";
@@ -301,6 +302,11 @@ class Data {
 			}
 		} catch(e:Dynamic) {}
 
+		var reqs = new Array<RequirementsInfos>();
+		try {
+			reqs = cast doc.requirements;
+		} catch (e: Dynamic) {}
+
 		var website = ( doc.url!=null ) ? Std.string(doc.url) : "";
 		var desc = ( doc.description!=null ) ? Std.string(doc.description) : "";
 		var version = try SemVer.ofString(Std.string(doc.version)).toString() catch (e:Dynamic) "0.0.0";
@@ -318,7 +324,8 @@ class Data {
 			classPath : classPath,
 			tags : tags,
 			developers : devs,
-			dependencies : deps
+			dependencies : deps,
+			requirements : reqs
 		};
 	}
 

--- a/src/tools/haxelib/Data.hx
+++ b/src/tools/haxelib/Data.hx
@@ -49,6 +49,19 @@ typedef ProjectInfos = {
 	var tags : List<String>;
 }
 
+typedef GitPackageInfos = {
+	var path                    : String; // Link to the repository
+	@:optional var branch       : String; // Git branch
+	@:optional var subdirectory : String; // Folder in the repository that would normally be bundled and submitted to haxelib
+}
+
+typedef RequirementsInfos = {
+	var name 			   : String; // Library's name
+	var type 			   : String; // Library's type (git | haxelib)
+	@:optional var version : String;
+	@:optional var package : GitPackageInfos; // Package's infos
+}
+
 typedef Infos = {
 	var project : String;
 	var website : String;
@@ -60,6 +73,7 @@ typedef Infos = {
 	var developers : List<String>;
 	var tags : List<String>;
 	var dependencies : List<{ project : String, version : String }>;
+	@:optional var requirements : Array<RequirementsInfos>; // To not break compatibilities with libs with "dependencies" only
 }
 
 class Data {
@@ -203,6 +217,50 @@ class Data {
 			case TClass(String):
 			case TNull: throw 'no releasenote specified';
 			default: throw 'releasenote should be string';
+		}
+
+		if (doc.requirements) {
+			switch Type.typeof(doc.requirements) {
+				case TClass(Array): 
+					var requirements : Array<Dynamic> = doc.requirements;
+					for (req in requirements.iterator()) {
+						switch Type.typeof(req) {
+							case TObject: 
+								for (field in Reflect.fields(req)) {
+									var value = Reflect.field(req, field);
+									switch Type.typeof(value) {
+										case TClass(String):
+											var key = Std.string(field);
+											if ("type" == key) {
+												if (Std.string(value) != "git" || Std.string(value) != "haxelib") {
+													throw "Only git and haxelib types are allowed as requirements type";
+												} else if ("package" == key && Std.string(value) != "git") {
+													throw "Package entry can only be used by git libraries";
+												}
+											}
+											else if ("version" == key) {
+												try {
+													SemVer.ofString(val);
+												} catch(e:String) {
+													throw 'Requirement $field has an invalid version `$value`.';
+												}
+											}
+										case TObject:
+											for (f in Reflect.fields(value)) {
+												var val = Reflect.field(value, f);
+												switch Type.typeof(value) {
+													case TClass(String):
+														continue;
+													default: throw 'Package $f has an invalid datatype';
+												}
+											}
+										default: throw "Invalid requirements structure";
+									}
+								}
+						}
+					}
+				default: throw "requirements must be defined as array";
+			}
 		}
 	}
 


### PR DESCRIPTION
Hello,

This PR introduce a new way (more flexible) to declare dependencies in haxelib.json file
To not break current libraries, I added a new key "requirements", which is an array that contains informations about these dependencies.

You can have a look to a test JSON file here : https://github.com/Peekmo/Peekmo-haxe-tools/blob/master/haxelib.json

Why ? Because in a company, you don't always want to share your libraries on haxelib, and for moment, that's impossible to download dependencies from a GIT project, and more, that's impossible to declare dependencies to git project inside a haxelib project. And that's my need, to be able to share my tools without adding them to haxelib (because they are not really interesting outside my projects).

My idea is (perhaps) not the best, but with this kind of declaration, we could support subversion for example (just for example XD), or something else, who know the future ? 

The "version" for a git project => git tag

Thank you for your reading.
