### PR TITLE
Add "-D mylib=1.0.0" instead of only "-D mylib" for haxelib path

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -1055,7 +1055,7 @@ class Main {
 				dir = Path.addTrailingSlash( dir + cp );
 			}
 			Sys.println(dir);
-			Sys.println("-D "+d.project);
+			Sys.println("-D " + d.project + "="+d.info.version);
 		}
 	}
 


### PR DESCRIPTION
When you run "haxelib path", it automatically defines the name of the library. In order to make this even more valuable, now that Haxe includes support for defines and values, I think that the value should automatically be set to the project version.

This means that you will not only be able to check for the existence of library...

``` haxe
#if (mylib) trace ("Hello!"); #end
```

...but also check for the version:

``` haxe
#if (mylib > "1.0.0") trace ("New release!"); #end
```
