### PR TITLE
Fix issue using "haxelib run" in CI on Windows

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -712,10 +712,14 @@ class Main {
 			haxepath = Path.addTrailingSlash( haxepath );
 		var envPath = Sys.getEnv("HAXELIB_PATH");
 		var config_file;
-		if( win )
-			config_file = Sys.getEnv("HOMEDRIVE") + Sys.getEnv("HOMEPATH");
-		else
+		if( win ) {
+			if (Sys.getEnv("HOMEDRIVE") != null && Sys.getEnv("HOMEPATH") != null)
+				config_file = Sys.getEnv("HOMEDRIVE") + Sys.getEnv("HOMEPATH");
+			else
+				config_file = "C:\Users";
+		} else {
 			config_file = Sys.getEnv("HOME");
+		}
 		config_file += "/.haxelib";
 		var rep = if (envPath != null)
 			envPath


### PR DESCRIPTION
In certain continuous environments, HOMEDRIVE and HOMEPATH are not defined, but this tweak should allow it to continue to build

https://github.com/HaxeFoundation/haxelib/issues/78