### PR TITLE
Adding Apache license to haxelib tool.

### DIFF
--- a/src/tools/haxelib/Data.hx
+++ b/src/tools/haxelib/Data.hx
@@ -106,6 +106,7 @@ typedef Infos = {
 	var Mit = 'MIT';
 	var Bsd = 'BSD';
 	var Public = 'Public';
+	var Apache = 'Apache';
 }
 
 abstract ProjectName(String) to String {


### PR DESCRIPTION
Reasoning:
 * The Apache 2.0 license is quite often used, [according to Ohloh/Blackduck](https://www.blackducksoftware.com/resources/data/top-20-open-source-licenses) it is the #3 in 2014 at 16% overall usage. This is more than GPL 3, BSD 2 or any of the LGPL. Only MIT and GPL 2 do have a higher usage.
 * There were no significant arguments against it in [this thread from 2010](http://old.haxe.org/forum/thread/3395#nabble-td5546987) other than the intention to avoid a "license hell", which is of course understandable, but does obviously no longer apply to the Apache 2.0 license.
