### PR TITLE
Support haxelib upgrade without "haxelib selfupdate"

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -151,7 +151,30 @@ class Main {
 
 	function new() {
 		args = Sys.args();
-
+		
+		if (args.length == 0 || (args[0] != "-redirect" && args[0] != "setup")) {
+			try {
+				var rep = getRepository ();
+				var list = new List ();
+				checkRec ("haxelib_client", null, list);
+				var d = list.pop ();
+				if (d != null) {
+					var pdir = Data.safe(d.project)+"/"+Data.safe(d.version)+"/";
+					var dir = rep + pdir;
+					try {
+						dir = getDev(rep+Data.safe(d.project));
+						dir = Path.addTrailingSlash(dir);
+						pdir = dir;
+					} catch ( e : Dynamic ) { }
+					var n = pdir + "/bin/haxelib.n";
+					if (FileSystem.exists (n)) {
+						var code = Sys.command ("neko", [ n, "-redirect" ].concat (args));
+						Sys.exit (code);
+					}
+				}
+			} catch (e:Dynamic) {}
+		}
+		
 		commands = new List();
 		addCommand("install", install, "install a given library, or all libraries from a hxml file", Basic);
 		addCommand("upgrade", upgrade, "upgrade all installed libraries", Basic);
@@ -264,6 +287,7 @@ class Main {
 			if( a == null )
 				break;
 			switch( a ) {
+			case "-redirect":
 			case "-debug":
 				debug = true;
 			case "-notimeout":


### PR DESCRIPTION
There are other ways to solve this problem, but the following is a solution that allows a single haxelib script to be compiled to an executable and stored in the Haxe directory, while also using the same executable elsewhere, installed using the "haxelib_client" lib.

Currently, upgrading haxelib is a hassle. On Windows (for example), you use:

    haxelib selfupgrade
    haxe update.hxml

...and this may very well fail. It does on my system.

Instead of replacing "haxelib.exe" (which is brittle), I believe that the standard haxelib executable should work as a shim to run the upgraded version of haxelib. This is trickier, since the haxelib repository may not be setup, yet, but this system tries to run the "haxelib_client" version if it exists with a haxelib.n binary, and otherwise uses itself to process the commands.

This could allow haxelib to be updated using "haxelib upgrade" like other libraries. Similarly, you could "haxelib dev haxelib_client path/to/haxelib_client/clone" and work on haxelib directly.

I'm not sure if we should try using "haxe --run" instead of using Neko to call the haxelib.n binary, I wasn't immediately sure how "haxe --run" worked with arguments so I opted for this solution instead. A "haxe --run" solution could be nice because it would work without recompiling the haxelib client code (not sure if that's good or bad, though, if you're working on the file)