### PR TITLE
haxelib version and help

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -170,6 +170,7 @@ class Main {
 		addCommand("config", config, "print the repository path", Information, false);
 		addCommand("path", path, "give paths to libraries", Information, false);
 		addCommand("version", version, "print the currently using haxelib version", Information, false);
+		addCommand("help", usage, "display this list of options", Information, false);
 
 		addCommand("submit", submit, "submit or update a library package", Development);
 		addCommand("register", register, "register a new user", Development);
@@ -259,7 +260,6 @@ class Main {
 				print("    " + StringTools.rpad(c.name, " ", maxLength) + ": " +c.doc);
 			}
 		}
-		Sys.exit(1);
 	}
 
 	function process() {
@@ -291,8 +291,10 @@ class Main {
 			}
 		}
 		var cmd = args[argcur++];
-		if( cmd == null )
+		if( cmd == null ) {
 			usage();
+			Sys.exit(1);
+		}
 		for( c in commands )
 			if( c.name == cmd ) {
 				try {
@@ -321,6 +323,7 @@ class Main {
 			}
 		print("Unknown command "+cmd);
 		usage();
+		Sys.exit(1);
 	}
 
 	// ---- COMMANDS --------------------

--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -169,6 +169,7 @@ class Main {
 		addCommand("user", user, "list information on a given user", Information);
 		addCommand("config", config, "print the repository path", Information, false);
 		addCommand("path", path, "give paths to libraries", Information, false);
+		addCommand("version", version, "print the currently using haxelib version", Information, false);
 
 		addCommand("submit", submit, "submit or update a library package", Development);
 		addCommand("register", register, "register a new user", Development);
@@ -235,6 +236,10 @@ class Main {
 
 	function addCommand( name, f, doc, cat, ?net = true ) {
 		commands.add({ name : name, doc : doc, f : f, net : net, cat : cat });
+	}
+
+	function version() {
+		print(VERSION);
 	}
 
 	function usage() {


### PR DESCRIPTION
Added two simple commands:
 * `haxelib version` prints the currently using haxelib version.
 * `haxelib help` prints haxelib usage.

I'm not sure if we should add alias in the form of flags, like `-h/--h/-help/--help` and `-version/--version`.