### PR TITLE
Propagate --always and --never answer to dependencies

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -144,10 +144,8 @@ class Cli
 	public var cwd(get_cwd, set_cwd):String;
 	private static var cwd_cache:String = null;
 
-
-	public function new()
-		defaultAnswer = null;
-
+	public function new() {
+ 	}
 
 	function get_cwd():String
 	{


### PR DESCRIPTION
- Possibly resolves #246 
- The issue was that when the Vcs class creates new Cli() instances, it
  clears the defaultAnswer value that was parsed from the command line
arguments at startup.  Not setting defaultAnswer to null in the Cli
constructor allows you to preserve the defaultAnswer (stored in the
static defaultAnswer_global var that backs defaultAnswer).
- I'm not sure if this change will have other unwanted side effects