### PR TITLE
Use safe project name for the zip download path (website)

### DIFF
--- a/src/website/api/ProjectApi.hx
+++ b/src/website/api/ProjectApi.hx
@@ -146,7 +146,8 @@ class ProjectApi extends UFApi {
 		Get the path to the zip file (relative to the script directory).
 	**/
 	public function getZipFilePath( project:String, version:String ):String {
-		var version = version.replace(".",",");
+		var project = Data.safe(project);
+		var version = Data.safe(version);
 		#if deploy
 			// On the haxe.org server, we want to access the repo from the old website.
 			// When we change the websites over we should probably move these over too.


### PR DESCRIPTION
Fix #221

In the cli https://github.com/HaxeFoundation/haxelib/blob/master/src/haxelib/Data.hx#L194-L196