### PR TITLE
Fix FileSystem.fullPath error when directory doesn't exist

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1223,11 +1223,11 @@ class Main {
 			while ( dir.endsWith("/") || dir.endsWith("\\") ) {
 				dir = dir.substr(0,-1);
 			}
-			dir = FileSystem.fullPath(dir);
 			if (!FileSystem.exists(dir))
 				print('Directory $dir does not exist');
 			else
 				try {
+					dir = FileSystem.fullPath(dir);
 					File.saveContent(devfile, dir);
 					print("Development directory set to "+dir);
 				}


### PR DESCRIPTION
If you try to do `haxelib dev` on a directory that doesn't exist `FileSystem.fullPath` will throw a `std@file_full_path` error before the `exists` check is run.