### PR TITLE
Update of creating-a-haxelib-package.md

### DIFF
--- a/www/documentation-files/creating-a-haxelib-package.md
+++ b/www/documentation-files/creating-a-haxelib-package.md
@@ -8,13 +8,13 @@ Each Haxe library requires a `haxelib.json` file in which the following attribut
 
 * name: The name of the library. It must contain at least 3 characters among the following: `[A-Za-z0-9_-.]`. In particular, no spaces are allowed.
 * url: The URL of the library, i.e. where more information can be found.
-* license: The license under which the library is released. Can be `GPL`, `LGPL`, `BSD`, `Public` (for Public Domain) or `MIT`.
+* license: The license under which the library is released. Can be `GPL`, `LGPL`, `BSD`, `Public` (for Public Domain), `MIT`, or `Apache`.
 * tags: An array of tag-strings which are used on the repository website to sort libraries.
 * description: The description of what the library is doing.
 * version: The version string of the library. This is detailed in [Versioning](#versioning).
 * classPath: The path string to the source files.
 * releasenote: The release notes of the current version.
-* contributors: An array of user names which identify contributors to the library.
+* contributors: An array of user names which identify contributors to the library that are allowed to upload to haxelib.
 * dependencies: An object describing the dependencies of the library. This is detailed in [Dependencies](haxelib-json-dependencies.md).
 
 The following JSON is a simple example of a haxelib.json:


### PR DESCRIPTION
Added `Apache` to list of allowed licenses and clarified meaning of contributors field.