### PR TITLE
Website: only update a project shown version if it's a higher semver

### DIFF
--- a/src/haxelib/server/Repo.hx
+++ b/src/haxelib/server/Repo.hx
@@ -315,7 +315,11 @@ class Repo implements SiteApi {
 				v.documentation = doc;
 				v.insert();
 
-				p.versionObj = v;
+				// p.versionObj is the one shown on the website
+				if (p.versionObj != null && p.versionObj.toSemver() < v.toSemver()) {
+					p.versionObj = v;
+				}
+
 				p.update();
 				return "Version " + v.toSemver() + " (id#" + v.id + ") added";
 			}


### PR DESCRIPTION
`versionObj` is used to store the current version of a lib
ie. the one shown when looking at it http://lib.haxe.org/p/haxelib_client

It's not the same as the one selected by the client as latest which uses semver.

Currently if you upload a patch to an old version it'll overwrite `versionObj`.
