### PR TITLE
Some project from the DB are null, don't try to construct object for …

### DIFF
--- a/src/website/controller/HomeController.hx
+++ b/src/website/controller/HomeController.hx
@@ -165,7 +165,7 @@ class HomeController extends Controller {
 	}
 
 	static function prepareProjectList( list:Array<Project> ):Array<{ name:String, author:String, description:String, version:String, downloads:Int }> {
-		return [for (p in list) {
+		return [for (p in list) if (p != null) {
 			name: p.name,
 			author: p.ownerObj.name,
 			description: p.description,


### PR DESCRIPTION
…them

Should fix #342 http://lib.haxe.org/t/cross/ fails with `Invalid field access : name`
but http://lib.haxe.org/t/cross.json/ works and contains some `null`