### PR TITLE
Don't display project with invalid internal links

### DIFF
--- a/src/website/controller/HomeController.hx
+++ b/src/website/controller/HomeController.hx
@@ -165,7 +165,7 @@ class HomeController extends Controller {
 	}
 
 	static function prepareProjectList( list:Array<Project> ):Array<{ name:String, author:String, description:String, version:String, downloads:Int }> {
-		return [for (p in list) if (p != null) {
+		return [for (p in list) if (p != null && p.ownerObj != null && p.versionObj != null) {
 			name: p.name,
 			author: p.ownerObj.name,
 			description: p.description,


### PR DESCRIPTION
Now there shouldn't be any error when trying to parse the list even if some cross table links are broken.
#342.