### PR TITLE
Git dependencies fix

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1418,6 +1418,8 @@ class Main {
 			print("Library "+libName+" current version is now "+vcs.directory);
 		}
 
+		this.alreadyUpdatedVcsDependencies.set(libName, branch);
+
 		if(FileSystem.exists(jsonPath))
 			doInstallDependencies(rep, Data.readData(File.getContent(jsonPath), false).dependencies);
 	}


### PR DESCRIPTION
Library and branch must be stored after the first installation as well otherwise it'll be updated when another library depends on git version without specified commit-ish.

Example:
- Clean lib folder or `newrepo`
- Top level git dependency with specific commit hash
- Another top level git dependency depending on the previous one but without specified commit-ish
- First one is cloned properly
- When second one's dependencies are being cloned it should not do anything with the existing git repo of the first one (old behavior was that it updated it which shouldn't happen as specified version/branch must always precede any "don't care" version/branch)