### PR TITLE
Parse/autoinstall hg dependency

### DIFF
--- a/src/haxelib/Data.hx
+++ b/src/haxelib/Data.hx
@@ -81,19 +81,9 @@ abstract Dependencies(Dynamic<DependencyVersion>) from Dynamic<DependencyVersion
 			var value:String = Reflect.field(this, f);
 
 			var isGit = value != null && (value + "").startsWith("git:"); 
+			var isHg = value != null && (value + "").startsWith("hg:"); 
 			
-			if ( !isGit )
-			{
-				result.push ({
-					name: f,
-					type: (DependencyType.Haxelib : DependencyType),
-					version: (cast value : DependencyVersion),
-					url: (null : String),
-					subDir: (null : String),
-					branch: (null : String),
-				});
-			}
-			else
+			if ( isGit )
 			{
 				value = value.substr(4);
 				var urlParts = value.split("#");
@@ -109,7 +99,33 @@ abstract Dependencies(Dynamic<DependencyVersion>) from Dynamic<DependencyVersion
 					branch: (branch : String),
 				});
 			}
-			
+			else if ( isHg )
+			{
+				value = value.substr(3);
+				var urlParts = value.split("#");
+				var url = urlParts[0];
+				var branch = urlParts.length > 1 ? urlParts[1] : null;
+				
+				result.push ({
+					name: f,
+					type: (DependencyType.Mercurial : DependencyType),
+					version: (DependencyVersion.DEFAULT : DependencyVersion),
+					url: (url : String),
+					subDir: (null : String),
+					branch: (branch : String),
+				});
+			}
+			else
+			{
+				result.push ({
+					name: f,
+					type: (DependencyType.Haxelib : DependencyType),
+					version: (cast value : DependencyVersion),
+					url: (null : String),
+					subDir: (null : String),
+					branch: (null : String),
+				});
+			}
 			
 		}
 		

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -699,9 +699,15 @@ class Main {
 					{
 						if ( parts[1].startsWith("git:") )
 						{
-							
 							type = "git";
 							var urlParts = parts[1].substr(4).split("#");
+							url = urlParts[0];
+							branch = urlParts.length > 1 ? urlParts[1] : null;
+						}
+						else if ( parts[1].startsWith("hg:") )
+						{
+							type = "hg";
+							var urlParts = parts[1].substr(3).split("#");
 							url = urlParts[0];
 							branch = urlParts.length > 1 ? urlParts[1] : null;
 						}
@@ -737,9 +743,9 @@ class Main {
 		print("Loading info about the required libraries");
 		for (l in libsToInstall)
 		{
-			if ( l.type == "git" )
+			if ( l.type == "git" || l.type == "hg" )
 			{
-				// Do not check git repository infos
+				// Do not check git/hg repository infos
 				continue;
 			}
 			var inf = site.infos(l.name);

--- a/test/libraries/UseGitDep/hg.haxelib.json
+++ b/test/libraries/UseGitDep/hg.haxelib.json
@@ -1,0 +1,13 @@
+{
+	"name": "Foo",
+	"url" : "http://example.org",
+	"license": "GPL",
+	"tags": ["foo", "test"],
+	"description": "This project is an example of an haxelib project",
+	"version": "0.1.0-alpha.0",
+	"releasenote": "Initial release, everything is working correctly",
+	"dependencies": {
+		"signal": "hg:https://bitbucket.org/fzzr/hx.signal"
+	},
+	"contributors": ["Foo"]
+}

--- a/test/libraries/UseGitDep/hg.tag_haxelib.json
+++ b/test/libraries/UseGitDep/hg.tag_haxelib.json
@@ -1,0 +1,13 @@
+{
+	"name": "Foo",
+	"url" : "http://example.org",
+	"license": "GPL",
+	"tags": ["foo", "test"],
+	"description": "This project is an example of an haxelib project",
+	"version": "0.1.0-alpha.0",
+	"releasenote": "Initial release, everything is working correctly",
+	"dependencies": {
+		"signal": "hg:https://bitbucket.org/fzzr/hx.signal#develop"
+	},
+	"contributors": ["Foo"]
+}

--- a/test/tests/TestInstall.hx
+++ b/test/tests/TestInstall.hx
@@ -64,6 +64,14 @@ class TestInstall extends TestBase
 		
 		checkLibrary(getLibraryName());
 	}
+
+	public function testInstallHaxelibHgParameter():Void
+	{
+		var r = runHaxelib(["--debug", "install", "hg.haxelib.json"]);
+		assertTrue(r.exitCode == 0);
+		
+		checkLibrary(getLibraryName(), "hg");
+	}
 	
 	public function testInstallHaxelibDependencyWithTag():Void
 	{
@@ -76,6 +84,18 @@ class TestInstall extends TestBase
 		// if that repo "README.md" was added in tag/rev.: "0.9.3"
 		assertFalse(FileSystem.exists(Path.join([lib, "git", "README.md"])));
 	}
+
+	public function testInstallHaxelibHgDependencyWithTag():Void
+	{
+		var r = runHaxelib(["install", "hg.tag_haxelib.json"]);
+		assertTrue(r.exitCode == 0);
+		
+		var lib = getLibraryName();
+		checkLibrary(lib, "hg");
+		
+		// if that repo "README.md" was added in tag/rev.: "0.9.2"
+		assertFalse(FileSystem.exists(Path.join([lib, "hg", "README.md"])));
+	}
 	
 	function getLibraryName():String
 	{
@@ -85,7 +105,7 @@ class TestInstall extends TestBase
 		return details.dependencies.toArray()[0].name;
 	}
 	
-	function checkLibrary(lib:String):Void
+	function checkLibrary(lib:String, type = "git"):Void
 	{
 		// Library folder exists
 		var libFolder = Path.join([repo, lib]);
@@ -94,7 +114,7 @@ class TestInstall extends TestBase
 		
 		// Library version is set to git
 		var current = File.read(Path.join([libFolder, ".current"]), false);
-		assertTrue(current.readAll().toString() == "git");
+		assertTrue(current.readAll().toString() == type);
 		current.close();
 	}
 


### PR DESCRIPTION
Added hg libraries parser for haxelib/hxml files. Relative to https://github.com/HaxeFoundation/haxelib/pull/344

supported format
```
"dependencies": {
		"signal": "hg:https://bitbucket.org/fzzr/hx.signal#develop"
	},

-lib signal:hg:https://bitbucket.org/fzzr/hx.signal#develop
```