### PR TITLE
Add wildcard version support

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -652,16 +652,21 @@ class Main {
 		if( inf.versions.length == 0 )
 			throw "The library "+inf.name+" has not yet released a version";
 		var version = if( reqversion != null ) reqversion else inf.getLatest();
-		var found = false;
+		var matches = [];
+		var best = null;
 		for( v in inf.versions )
-			if( v.name == version ) {
-				found = true;
-				break;
+			if( matchVersion(version,v.name) ) {
+				matches.push(v.name);
 			}
-		if( !found )
+		for( match in matches ) {
+			if (best == null || match > best) {
+				best = match;
+			}
+		}
+		if( best == null )
 			throw "No such version "+version+" for library "+inf.name;
 
-		return version;
+		return best;
 	}
 
 	function installFromHxml( rep:String, path:String ) {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1086,16 +1086,23 @@ class Main {
 				continue;
 			v = Data.unsafe(v);
 			var semver = try SemVer.ofString(v) catch (_:Dynamic) null;
+			if ( semver == null ) {
+				var json = try File.getContent(dir+"/"+v+"/"+Data.JSON) catch( e : Dynamic ) null;
+				if ( json != null ) {
+					var inf = Data.readData(json, false);
+					semver = try SemVer.ofString(inf.version) catch (_:Dynamic) null;
+				}
+			}
 			if (semver != null && matchVersion(version, semver))
-				matches.push(semver);
+				matches.push({ dir: v, ver: semver });
 		}
-		var best = null;
+		var best:Dynamic = null;
 		for( match in matches ) {
-			if (best == null || match > best) {
+			if (best == null || match.ver > best.ver) {
 				best = match;
 			}
 		}
-		return if (best != null) dir + "/" + Data.safe(best) else null;
+		return if (best != null) dir + "/" + Data.safe(best.dir) else null;
 	}
 
 	function list() {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1290,7 +1290,7 @@ class Main {
 		var dev = try getDev(pdir) catch (_:Dynamic) null;
 		var vdir = try getVersionDir(version,dev,pdir) catch (_:Dynamic) null;
 
-		if( vdir != null && !FileSystem.exists(vdir) )
+		if( vdir == null || !FileSystem.exists(vdir) )
 			throw "Library "+prj+" version "+version+" is not installed";
 
 		for( p in l )

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1079,9 +1079,13 @@ class Main {
 				return dev;
 			}
 		}
+		var current = try getCurrent(dir) catch(e:Dynamic) null;
+		if ( current != null && matchVersion(version, current) ) {
+			return dir+"/"+Data.safe(current);
+		}
 		var matches = [];
 		for( v in FileSystem.readDirectory(dir) ) {
-			if( v == version) return dir + "/" + v;
+			if( v == version ) return dir+"/"+v;
 			if( v.charAt(0) == "." )
 				continue;
 			v = Data.unsafe(v);
@@ -1098,7 +1102,7 @@ class Main {
 		}
 		var best:Dynamic = null;
 		for( match in matches ) {
-			if (best == null || match.ver > best.ver) {
+			if (best == null || match.ver > best.ver || (match.ver == best.ver && match.dir.indexOf (",") == -1)) {
 				best = match;
 			}
 		}

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1081,6 +1081,7 @@ class Main {
 		}
 		var matches = [];
 		for( v in FileSystem.readDirectory(dir) ) {
+			if( v == version) return dir + "/" + v;
 			if( v.charAt(0) == "." )
 				continue;
 			v = Data.unsafe(v);


### PR DESCRIPTION
This is the start of a set of updates to add wildcard version support to haxelib

 1.) This enables support for `haxelib install mylib 5.*` or `haxelib path mylib:1.0.*`
 2.) This enables `haxelib path mylib:1.0.1` even if a newer "dev" directory is set

`haxelib path` is unpredictable, because the "dev" directory always overrides the set version. That is valuable for getting the current library version, but this is troublesome if you are trying to retrieve the path of an older.

These changes reads "haxelib.json" of dev paths in order to determine what version it is.

Imagine that there is a library called "mylib", with a development directory (version 1.2.0) set:

```bash
mylib: 1.0.0 1.0.1 1.1.0 [dev:C:\mylib]
```

Currently haxelib will return the following:

```bash
> haxelib path mylib
C:\mylib
-D mylib=1.2.0
> haxelib path mylib:1.1.0
C:\mylib
-D mylib=1.1.0
> haxelib path mylib:1.0.0
C:\mylib
-D mylib=1.0.0
```

This is very confusing, and prevents us from getting older paths. These changes enable the following output

```bash
> haxelib path mylib
C:\mylib
-D mylib=1.2.0
> haxelib path mylib:1.1.0
C:\HaxeToolkit\haxe\lib\mylib\1,1,0
-D mylib=1.1.0
> haxelib path mylib:1.0.0
C:\HaxeToolkit\haxe\lib\mylib\1,0,0
-D mylib=1.0.0
> haxelib path mylib:1.*
C:\mylib
-D mylib=1.2.0
> haxelib path mylib:1.1.*
C:\HaxeToolkit\haxe\lib\mylib\1,1,0
-D mylib=1.1.0
> haxelib path mylib:1.0.*
C:\HaxeToolkit\haxe\lib\mylib\1,0,0
-D mylib=1.0.0
```

This should enable use of a "dev" directory matching an older version number, and developers who always use "dev" for current library versions, but may need to build a project using an older library version as well. This only affects projects that request an exact version, instead of the current version

The goal of wildcard version numbers is to allow looser dependencies. According to SemVer, both minor and patch releases should remain backward compatible. A developer may choose to require "mylib" version "2.*" in this way, without updating each time there is a new minor or patch release, or without supporting any installed version