### PR TITLE
Add support for custom local directories and wildcard versions

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -652,16 +652,21 @@ class Main {
 		if( inf.versions.length == 0 )
 			throw "The library "+inf.name+" has not yet released a version";
 		var version = if( reqversion != null ) reqversion else inf.getLatest();
-		var found = false;
+		var matches = [];
+		var best = null;
 		for( v in inf.versions )
-			if( v.name == version ) {
-				found = true;
-				break;
+			if( matchVersion(version,v.name) ) {
+				matches.push(v.name);
 			}
-		if( !found )
+		for( match in matches ) {
+			if (best == null || match > best) {
+				best = match;
+			}
+		}
+		if( best == null )
 			throw "No such version "+version+" for library "+inf.name;
 
-		return version;
+		return best;
 	}
 
 	function installFromHxml( rep:String, path:String ) {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1086,16 +1086,23 @@ class Main {
 				continue;
 			v = Data.unsafe(v);
 			var semver = try SemVer.ofString(v) catch (_:Dynamic) null;
+			if ( semver == null ) {
+				var json = try File.getContent(dir+"/"+v+"/"+Data.JSON) catch( e : Dynamic ) null;
+				if ( json != null ) {
+					var inf = Data.readData(json, false);
+					semver = try SemVer.ofString(inf.version) catch (_:Dynamic) null;
+				}
+			}
 			if (semver != null && matchVersion(version, semver))
-				matches.push(semver);
+				matches.push({ dir: v, ver: semver });
 		}
-		var best = null;
+		var best:Dynamic = null;
 		for( match in matches ) {
-			if (best == null || match > best) {
+			if (best == null || match.ver > best.ver) {
 				best = match;
 			}
 		}
-		return if (best != null) dir + "/" + Data.safe(best) else null;
+		return if (best != null) dir + "/" + Data.safe(best.dir) else null;
 	}
 
 	function list() {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1290,7 +1290,7 @@ class Main {
 		var dev = try getDev(pdir) catch (_:Dynamic) null;
 		var vdir = try getVersionDir(version,dev,pdir) catch (_:Dynamic) null;
 
-		if( vdir != null && !FileSystem.exists(vdir) )
+		if( vdir == null || !FileSystem.exists(vdir) )
 			throw "Library "+prj+" version "+version+" is not installed";
 
 		for( p in l )

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1079,9 +1079,13 @@ class Main {
 				return dev;
 			}
 		}
+		var current = try getCurrent(dir) catch(e:Dynamic) null;
+		if ( current != null && matchVersion(version, current) ) {
+			return dir+"/"+Data.safe(current);
+		}
 		var matches = [];
 		for( v in FileSystem.readDirectory(dir) ) {
-			if( v == version) return dir + "/" + v;
+			if( v == version ) return dir+"/"+v;
 			if( v.charAt(0) == "." )
 				continue;
 			v = Data.unsafe(v);
@@ -1098,7 +1102,7 @@ class Main {
 		}
 		var best:Dynamic = null;
 		for( match in matches ) {
-			if (best == null || match.ver > best.ver) {
+			if (best == null || match.ver > best.ver || (match.ver == best.ver && match.dir.indexOf (",") == -1)) {
 				best = match;
 			}
 		}

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1081,6 +1081,7 @@ class Main {
 		}
 		var matches = [];
 		for( v in FileSystem.readDirectory(dir) ) {
+			if( v == version) return dir + "/" + v;
 			if( v.charAt(0) == "." )
 				continue;
 			v = Data.unsafe(v);

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1628,7 +1628,7 @@ class Main {
 		if (version == null)
 			version = getCurrent(pdir);
 		var dev = try getDev(pdir) catch ( e : Dynamic ) null;
-		var vdir = dev != null ? dev : pdir + Data.safe(version);
+		var vdir = dev != null ? dev : getVersionDir(version, pdir);
 
 		var infos =
 			try

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1068,7 +1068,7 @@ class Main {
 		if (other == "" || other == null)
 			return false;
 		var filter = version.replace(".","\\.").replace("*",".*");
-		return new EReg("^"+filter,"i").match(other);
+		return new EReg("^"+filter+"$","i").match(other);
 	}
 
 	function getVersionDir( version, dev, dir ) {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1521,6 +1521,8 @@ class Main {
 		if( dir == null ) {
 			if( FileSystem.exists(devfile) )
 				FileSystem.deleteFile(devfile);
+			if( !FileSystem.exists(proj+"/.current") )
+				try { FileSystem.deleteDirectory(proj); } catch (e:Dynamic) {}
 			print("Development directory disabled");
 		}
 		else {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1071,14 +1071,7 @@ class Main {
 		return new EReg("^"+filter+"$","i").match(other);
 	}
 
-	function getVersionDir( version, dev, dir ) {
-		if ( dev != null ) {
-			var json = try File.getContent(dev+"/"+Data.JSON) catch( e : Dynamic ) null;
-			var inf = Data.readData(json, false);
-			if ( version == "dev" || matchVersion(version, inf.version) ) {
-				return dev;
-			}
-		}
+	function getVersionDir( version, dir ) {
 		var current = try getCurrent(dir) catch(e:Dynamic) null;
 		if ( current != null && matchVersion(version, current) ) {
 			return dir+"/"+Data.safe(current);
@@ -1300,8 +1293,8 @@ class Main {
 		var version = if( version != null ) version else getCurrent(pdir);
 
 		var dev = try getDev(pdir) catch (_:Dynamic) null;
-		var vdir = try getVersionDir(version,dev,pdir) catch (_:Dynamic) null;
-
+		var vdir = if (dev != null) dev else try getVersionDir(version,pdir) catch (_:Dynamic) null;
+		
 		if( vdir == null || !FileSystem.exists(vdir) )
 			throw "Library "+prj+" version "+version+" is not installed";
 

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1157,16 +1157,16 @@ class Main {
 		var current = try getCurrent(dir) catch (e:Dynamic) null;
 		if ( current != null ) {
 			var semver = try SemVer.ofString(current) catch (_:Dynamic) null;
+			var vdir = dir+"/"+Data.safe(current);
 			if ( semver == null ) {
-				var vdir = dir+"/"+Data.safe(current);
 				if ( !sys.FileSystem.exists(vdir) ) {
 					var localdir = getLocal(dir, current);
 					if( localdir != null )
 						vdir = localdir;
 				}
-				if ( sys.FileSystem.exists(vdir) ) {
-					return vdir;
-				}
+			}
+			if ( sys.FileSystem.exists(vdir) ) {
+				return vdir;
 			}
 		}
 		return null;


### PR DESCRIPTION
This adds support for two additional features:

## Custom Local Directories

`haxelib dev` enables the use of a custom local directory, but forces an "override always" behavior that can be undesirable. This adds support for custom named directories, with the default being called "local". The current syntax is as follows:

```bash
haxelib install path/to/mylib
haxelib install path/to/mylib custom_name
```

`haxelib install path/to/mylib` will install "local" with a path to "path/to/mylib", while adding the optional "custom_name" argument installs it as "custom_name"

> 1.0.0 1.0.1 [local:path/to/mylib]

You should be able to remove, set and path similar to other types of versions

## Wildcard Versions

There is also added support for wildcard versioning:

```bash
haxelib version mylib
haxelib version mylib:1.0.0
haxelib version mylib:1.*
haxelib version mylib:1.0*
haxelib version mylib:1.0.0-*
haxelib version mylib:1.0.0-beta*
```

This should work for "install" and "path", there may be some commands (such as "set") that still need to have support added

I would be happy to discuss these features, and how they can be polished to fit in best