### PR TITLE
[WIP] Add haxelib downloads per day

### DIFF
--- a/src/haxelib/server/Repo.hx
+++ b/src/haxelib/server/Repo.hx
@@ -359,6 +359,17 @@ class Repo implements SiteApi {
 		v.update();
 		p.downloads++;
 		p.update();
+		
+		var d = Downloads.manager.select($pid == p.id);
+		if ( d == null ) {
+			d.pid = p.id;
+			d.num = 1;
+			d.date = Date.now();
+			d.insert();
+		} else {
+			d.num++;
+			d.update();
+		}
 	}
 
 	static function main() {

--- a/src/haxelib/server/SiteDb.hx
+++ b/src/haxelib/server/SiteDb.hx
@@ -109,6 +109,14 @@ class Version extends Object {
 
 }
 
+@:id(pid)
+@:index(date)
+class Downloads extends Object {
+	public var pid : Int;
+	public var date : SDate;
+	public var num : Int;
+}
+
 @:id(user,project)
 class Developer extends Object {
 


### PR DESCRIPTION
This is WIP . At the moment I add new table Downloads where every  haxelib install will be counted per day.
The main problem is how to show this data.  It's possible to be use  library 
https://github.com/fnando/sparkline and data to be  added in ```function infos(...)``` ( Repo.hx) and show in new tab ( at example before "All Versions " ) 