### PR TITLE
Prevent external diff tool launch.

### DIFF
--- a/src/haxelib/client/Vcs.hx
+++ b/src/haxelib/client/Vcs.hx
@@ -243,9 +243,9 @@ class Git extends Vcs {
 
 	override public function update(libName:String):Bool {
 		if (
-			command(executable, ["diff", "--exit-code"]).code != 0
+			command(executable, ["diff", "--exit-code", "--no-ext-diff"]).code != 0
 			||
-			command(executable, ["diff", "--cached", "--exit-code"]).code != 0
+			command(executable, ["diff", "--cached", "--exit-code", "--no-ext-diff"]).code != 0
 		) {
 			if (Cli.ask("Reset changes to " + libName + " " + name + " repo so we can pull latest version")) {
 				sure(command(executable, ["reset", "--hard"]));
@@ -328,7 +328,7 @@ class Mercurial extends Vcs {
 	override public function update(libName:String):Bool {
 		command(executable, ["pull"]);
 		var summary = command(executable, ["summary"]).out;
-		var diff = command(executable, ["diff", "-U", "2", "--git", "--subrepos"]);
+		var diff = command(executable, ["diff", "-U", "2", "--git", "--subrepos", "--no-ext-diff"]);
 		var status = command(executable, ["status"]);
 
 		// get new pulled changesets:


### PR DESCRIPTION
If you have an graphical diff tool defined in global or repo level
gitconfig this command will launch it rather then the text based
expected by the tool.

Fix is to add the switch —no-ext-diff fixes this, around since git 1.7.
See this for example of why this is an issue:
    https://github.com/pre-commit/pre-commit/issues/545