### PR TITLE
Support haxe 4 `--library` and `-L` flags with haxelib install

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -712,9 +712,10 @@ class Main {
 							libsToInstall[lib] = { name: lib, version: null, type:"haxelib", url: null, branch: null, subDir: null }
 					}
 
-				if (l.startsWith("-lib"))
+				var libraryFlagEReg = ~/^(-lib|-L|--library)\b/;
+				if (libraryFlagEReg.match(l))
 				{
-					var key = l.substr(5).trim();
+					var key = libraryFlagEReg.matchedRight().trim();
 					var parts = ~/:/.split(key);
 					var libName = parts[0];
 					var libVersion:String = null;


### PR DESCRIPTION
Running `haxelib install build.hxml` doesn't work if you specify your libraries with `-L` or `--library` (as suggested in the haxe 4 command doc)

This change matches `-lib`, `--library` and `-L` as library lines and fixes edge cases where invalid  flags like `-libx name` would pass but not correctly install