### PR TITLE
Fix GitHub spelling, update Connect menu

### DIFF
--- a/www/view/layout.html
+++ b/www/view/layout.html
@@ -90,11 +90,12 @@
 				<li class="dropdown">
 					<a href="/HaxeFoundation" data-toggle="dropdown" class="dropdown-toggle">Connect <b class="caret"></b></a>
 					<ul class="dropdown-menu">
-						<li><a href="https://github.com/HaxeFoundation" rel="external"><i class="fa fa-github"></i> Github</a></li>
+						<li><a href="https://github.com/HaxeFoundation" rel="external"><i class="fa fa-github"></i> GitHub</a></li>
 						<li><a href="https://github.com/HaxeFoundation/haxe/issues" rel="external"><i class="fa fa-github"></i> Bug reports</a></li>
-						<li><a href="https://stackoverflow.com/questions/tagged/haxe" rel="external"><i class="fa fa-stack-exchange"></i> Stack Overflow</a></li>
+						<li><a href="https://stackoverflow.com/questions/tagged/haxe" rel="external"><i class="fa fa-stack-overflow"></i> Stack Overflow</a></li>
 						<li><a href="http://community.haxe.org/" rel="external"><i class="fa fa-envelope-o"></i> Forums</a></li>
-						<li><a href="https://gitter.im/HaxeFoundation/haxe" rel="external nofollow"><i class="fa fa-comments-o"></i> Chat</a></li>
+						<li><a href="https://discordapp.com/invite/0uEuWH3spjck73Lo" rel="external nofollow"><i class="fa fa-comments-o"></i> Discord</a></li>
+						<li><a href="https://gitter.im/HaxeFoundation/haxe" rel="external nofollow"><i class="fa fa-comments-o"></i> Gitter</a></li>
 						<li><a href="https://haxe.org/blog"><i class="fa fa-rss"></i> Blog</a></li>
 						<li class="divider"></li>
 						<li><a href="https://www.facebook.com/haxe.org/" rel="external"><i class="fa fa-facebook"></i> Facebook</a></li>
@@ -142,9 +143,9 @@
 				</p>
 			</div>
 			<div class="span4">
-				<h3><i class="fa fa-big fa-globe"></i> Join us on Github!</h3>
+				<h3><i class="fa fa-big fa-globe"></i> Join us on GitHub!</h3>
 				<p>Haxe is being developed on GitHub. Feel free to contribute or report issues to our projects.</p>
-				<p><i class="fa fa-github"></i> <a href="https://github.com/HaxeFoundation/">Haxe on Github</a></p>
+				<p><i class="fa fa-github"></i> <a href="https://github.com/HaxeFoundation/">Haxe on GitHub</a></p>
 			</div>
 		</div>
   </div>
@@ -155,7 +156,7 @@
 		<div class="copyright">
 			<p>&copy;@todaysDate.getFullYear()
 				<a href="//haxe.org/foundation/" title="Haxe Foundation Website" class="hf-link">Haxe Foundation</a> | 
-				<a href="https://github.com/HaxeFoundation/haxelib" title="Haxelib Github Repository" class="hf-link">Haxelib on Github</a>
+				<a href="https://github.com/HaxeFoundation/haxelib" title="Haxelib GitHub Repository" class="hf-link">Haxelib on GitHub</a>
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
Applies the spelling fixes and connect menu changes that were done on haxe.org to lib.haxe.org too.