### PR TITLE
Better output format while installing. (MB)

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -71,10 +71,12 @@ class ProgressOut extends haxe.io.Output {
 	function report(n) {
 		cur += n;
 		curMB = cur / 1000000.0;
+		curMB = Math.round( curMB * Math.pow(10, 2) ) / Math.pow(10, 2); // 12.34 precision.
 		if( max == null )
 			Sys.print(curMB + " MB\r");
 		else {
 			maxMB = max / 1000000.0;
+			maxMB = Math.round( maxMB * Math.pow(10, 2) ) / Math.pow(10, 2); // 12.34 precision.
 			Sys.print((curMB + " / " + maxMB + " MB (" + Std.int((curMB*100.0)/maxMB) + "%)\r");
 		}
 	}

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -55,8 +55,10 @@ class ProgressOut extends haxe.io.Output {
 
 	var o : haxe.io.Output;
 	var cur : Int;
+	var curMB : Float;
 	var startSize : Int;
 	var max : Null<Int>;
+	var maxMB : Null<Float>;
 	var start : Float;
 
 	public function new(o, currentSize) {
@@ -68,10 +70,13 @@ class ProgressOut extends haxe.io.Output {
 
 	function report(n) {
 		cur += n;
+		curMB = cur / 1000000.0;
 		if( max == null )
-			Sys.print(cur+" bytes\r");
-		else
-			Sys.print(cur+"/"+max+" ("+Std.int((cur*100.0)/max)+"%)\r");
+			Sys.print(curMB + " MB\r");
+		else {
+			maxMB = max / 1000000.0;
+			Sys.print((curMB + "/" + maxMB + " (" + Std.int((curMB*100.0)/maxMB) + "%)\r");
+		}
 	}
 
 	public override function writeByte(c) {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -251,7 +251,10 @@ class Main {
 	}
 
 	function version() {
-		print(VERSION_LONG);
+		Sys.println('Haxelib\'s current version: ${VERSION_LONG}');
+
+		if (paramOpt())
+			Sys.println('! WARNING: \'version\' command is only for printing the haxelib\'s version.');
 	}
 
 	function usage() {
@@ -426,6 +429,9 @@ class Main {
 			Sys.exit(1);
 		}
 		if (cmd == "upgrade") cmd = "update"; // TODO: maybe we should have some alias system
+		if (commands.length != 0) {
+			Sys.println("Please ")
+		}
 		for( c in commands )
 			if( c.name == cmd ) {
 				switch (c.cat) {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -75,7 +75,7 @@ class ProgressOut extends haxe.io.Output {
 			Sys.print(curMB + " MB\r");
 		else {
 			maxMB = max / 1000000.0;
-			Sys.print((curMB + "/" + maxMB + " (" + Std.int((curMB*100.0)/maxMB) + "%)\r");
+			Sys.print((curMB + " / " + maxMB + " MB (" + Std.int((curMB*100.0)/maxMB) + "%)\r");
 		}
 	}
 


### PR DESCRIPTION
I know it is just a one time thing but...
Printing raw bytes number is not a good idea to give feedback about installing process to the user I think.

So I changed the output format like this. I hope you like it.
```
Old:
18739180/83729571 (22%)

New:
18.73 / 83.72 MB (22%)
```

Have a nice day :) 😄 