### PR TITLE
Add --skip-dependencies option

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -250,7 +250,8 @@ class Main {
 	function usage() {
 		var cats = [];
 		var maxLength = Lambda.fold(Reflect.fields(ABOUT_SETTINGS), function(opt, max) {
-			var len = opt.length + 2; // include -- in option name
+			var fullOption = '--' + ~/([A-Z])/g.replace(opt, "-$1").toLowerCase();
+			var len = fullOption.length;
 			return len > max ? len : max;
 		}, 0);
 
@@ -273,8 +274,10 @@ class Main {
 		}
 
 		print("  Available switches");
-		for (f in Reflect.fields(ABOUT_SETTINGS))
-			print('    --' + f.rpad(' ', maxLength-2) + ": " + Reflect.field(ABOUT_SETTINGS, f));
+		for (f in Reflect.fields(ABOUT_SETTINGS)) {
+			var option = ~/([A-Z])/g.replace(f, "-$1").toLowerCase().rpad(' ', maxLength-2);
+			print('    --' + option + ": " + Reflect.field(ABOUT_SETTINGS, f));
+		}
 	}
 	static var ABOUT_SETTINGS = {
 		global : "force global repo if a local one exists",

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -249,7 +249,11 @@ class Main {
 
 	function usage() {
 		var cats = [];
-		var maxLength = 0;
+		var maxLength = Lambda.fold(Reflect.fields(ABOUT_SETTINGS), function(opt, max) {
+			var len = opt.length + 2; // include -- in option name
+			return len > max ? len : max;
+		}, 0);
+
 		for( c in commands ) {
 			if (c.name.length > maxLength) maxLength = c.name.length;
 			if (c.cat.match(Deprecated(_))) continue;
@@ -280,7 +284,7 @@ class Main {
 		always : "answer all questions with yes",
 		never  : "answer all questions with no",
 		system : "run bundled haxelib version instead of latest update",
-		skipdeps : "do not install dependencies",
+		skipDependencies : "do not install dependencies",
 	}
 
 	var settings: {
@@ -291,7 +295,7 @@ class Main {
 		never  : Bool,
 		global : Bool,
 		system : Bool,
-		skipdeps : Bool,
+		skipDependencies : Bool,
 	};
 	function process() {
 		argcur = 0;
@@ -304,7 +308,7 @@ class Main {
 			flat: false,
 			global: false,
 			system: false,
-			skipdeps: false,
+			skipDependencies: false,
 		};
 
 		function parseSwitch(s:String) {
@@ -373,6 +377,8 @@ class Main {
 				case "--quiet":
 					settings.debug = false;
 					settings.quiet = true;
+				case "--skip-dependencies":
+					settings.skipDependencies = true;
 				case parseSwitch(_) => Some(s) if (Reflect.hasField(settings, s)):
 					//if (!Reflect.hasField(settings, s)) {
 						//print('unknown switch $a');
@@ -996,7 +1002,7 @@ class Main {
 	}
 
 	function doInstallDependencies( rep:String, dependencies:Array<Dependency> ) {
-		if( settings.skipdeps ) return;
+		if( settings.skipDependencies ) return;
 
 		for( d in dependencies ) {
 			if( d.version == "" ) {

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -280,6 +280,7 @@ class Main {
 		always : "answer all questions with yes",
 		never  : "answer all questions with no",
 		system : "run bundled haxelib version instead of latest update",
+		skipdeps : "do not install dependencies",
 	}
 
 	var settings: {
@@ -290,6 +291,7 @@ class Main {
 		never  : Bool,
 		global : Bool,
 		system : Bool,
+		skipdeps : Bool,
 	};
 	function process() {
 		argcur = 0;
@@ -302,6 +304,7 @@ class Main {
 			flat: false,
 			global: false,
 			system: false,
+			skipdeps: false,
 		};
 
 		function parseSwitch(s:String) {
@@ -993,6 +996,8 @@ class Main {
 	}
 
 	function doInstallDependencies( rep:String, dependencies:Array<Dependency> ) {
+		if( settings.skipdeps ) return;
+
 		for( d in dependencies ) {
 			if( d.version == "" ) {
 				var pdir = rep + Data.safe(d.name);


### PR DESCRIPTION
Fixes #343 with the most basic variant: just don't install any dependency listed in haxelib.json when this flag is set.

**Background:** I needed something like this to be able to use some libs meant to be used with lix and which cannot be installed without lix due to dependencies (conflicting versions or even libs never released on haxelib) [[Gist with scripts used for that]](https://gist.github.com/kLabz/e29722b3425ad2f36341d86d3612c117)

Updated help output:
```
Haxe Library Manager 3.4.0 - (c)2006-2019 Haxe Foundation
  Usage: haxelib [command] [options]
  Basic
    install            : install a given library, or all libraries from a hxml file
    update             : update a single library (if given) or all installed libraries
    remove             : remove a given library/version
    list               : list all installed libraries
    set                : set the current version for a library
  Information
    search             : list libraries matching a word
    info               : list information on a given library
    user               : list information on a given user
    config             : print the repository path
    path               : give paths to libraries' sources and necessary build definitions
    libpath            : returns the root path of a library
    version            : print the currently used haxelib version
    help               : display this list of options
  Development
    submit             : submit or update a library package
    register           : register a new user
    dev                : set the development directory for a given library
    git                : use Git repository as library
    hg                 : use Mercurial (hg) repository as library
  Miscellaneous
    setup              : set the haxelib repository path
    newrepo            : create a new local repository
    deleterepo         : delete the local repository
    convertxml         : convert haxelib.xml file to haxelib.json
    run                : run the specified library with parameters
    proxy              : setup the Http proxy
  Available switches
    --flat             : do not use --recursive cloning for git
    --always           : answer all questions with yes
    --debug            : run in debug mode, imply not --quiet
    --quiet            : print less messages, imply not --debug
    --system           : run bundled haxelib version instead of latest update
    --skip-dependencies: do not install dependencies
    --never            : answer all questions with no
    --global           : force global repo if a local one exists
```