### PR TITLE
Using more current compiler options

### DIFF
--- a/www/documentation-files/haxelibs-in-projects.md
+++ b/www/documentation-files/haxelibs-in-projects.md
@@ -1,17 +1,17 @@
 # Adding libraries to Haxe projects
 
-When the haxelib is installed, it is ready to be used it code. This is a matter of adding `-lib libraryname` to the [compiler arguments](https://haxe.org/manual/compiler-usage.html).
+When the haxelib is installed, it is ready to be used it code. This is a matter of adding `--library libraryname` (or `-L libraryname`) to the [compiler arguments](https://haxe.org/manual/compiler-usage.html).
 
 ```
-haxe -main Main -lib libraryname -js bin/main.js
+haxe --main Main --library libraryname --js bin/main.js
 ```
 
 The same parameters you pass to the compiler can be stored in a [hxml file](https://haxe.org/manual/compiler-usage-hxml.html):
 
 ```
--main Main
--lib libraryname
--js bin/main.js
+--main Main
+--library libraryname
+--js bin/main.js
 ```
 <hr/>
 

--- a/www/documentation-files/index.md
+++ b/www/documentation-files/index.md
@@ -6,7 +6,7 @@ A basic Haxe library is a collection of `.hx` files. That is, libraries are dist
 
 ### Using with Haxe
 
-Any installed Haxe library can be made available to the compiler through the `-lib <library-name>` argument. This is very similiar to the `-cp <path>` argument, but expects a library name instead of a directory path. These commands are explained thoroughly in [Compiler Usage](http://haxe.org/manual/compiler-usage.html).
+Any installed Haxe library can be made available to the compiler through the `--library <library-name>` (or `-L <library-name>`) argument. This is very similiar to the `--class-path <path>` argument, but expects a library name instead of a directory path. These commands are explained thoroughly in [Compiler Usage](http://haxe.org/manual/compiler-usage.html).
 
 For our exemplary usage we chose a very simple Haxe library called "random". It provides a set of static convenience methods to achieve various random effects, such as picking a random element from an array.
 
@@ -19,6 +19,6 @@ class Main {
 }
 ```
 
-Compiling this without any `-lib` argument causes an error message along the lines of `Unknown identifier : Random`. This shows that installed Haxe libraries are not available to the compiler by default unless they are explicitly added. A working command line for above program is `haxe -lib random -main Main --interp`.
+Compiling this without any `--library` argument causes an error message along the lines of `Unknown identifier : Random`. This shows that installed Haxe libraries are not available to the compiler by default unless they are explicitly added. A working command line for above program is `haxe --library random --main Main --interp`.
 
 If the compiler emits an error `Error: Library random is not installed : run 'haxelib install random'` the library has to be installed via the `haxelib` command first. As the error message suggests, this is achieved through `haxelib install random`. We will learn more about the `haxelib` command in [Using Haxelib](/documentation/using-haxelib/).

--- a/www/documentation-files/per-project-setup.md
+++ b/www/documentation-files/per-project-setup.md
@@ -16,7 +16,7 @@ Caveats:
 
 ### Using haxelib install all
 
-Haxe allows you to define specific versions of the libraries you want to use with `-lib <libname>:<version>`. If you make sure to use this in all your hxmls, then `haxelib install all --always` (the `--always` avoiding you being prompted for confirmation) will be able to ensure the libraries your project needs are available in the necessary versions. If in fact you run this in a checkout hook, your get to track your dependencies in your git repo (some other VCSs should allow for a similar setup), allowing you to have a well defined and replicable setup for any state (commit/branch/etc.).
+Haxe allows you to define specific versions of the libraries you want to use with `--library <libname>:<version>`. If you make sure to use this in all your hxmls, then `haxelib install all --always` (the `--always` avoiding you being prompted for confirmation) will be able to ensure the libraries your project needs are available in the necessary versions. If in fact you run this in a checkout hook, your get to track your dependencies in your git repo (some other VCSs should allow for a similar setup), allowing you to have a well defined and replicable setup for any state (commit/branch/etc.).
 
 Disadvantages:
 
@@ -30,7 +30,7 @@ Advantages:
 
 #### Using haxelib with git versions
 
-You can specify git versions with `-lib libname:git:https://github.com/user/repo#branch` branch can be a branch or a specific commit SHA. 
+You can specify git versions with `--library libname:git:https://github.com/user/repo#branch` branch can be a branch or a specific commit SHA. 
 As alternative, you might use git submodules instead, they also provide an adequate way of definining a *versionable* and *replicable* state.
 
 ### Combining both approaches


### PR DESCRIPTION
`-L|--library` rather than `-lib`. Similarly for `-js` to `--js`.