### PR TITLE
Typo fix in documentation/using-haxelib

### DIFF
--- a/www/documentation-files/using-haxelib.md
+++ b/www/documentation-files/using-haxelib.md
@@ -363,7 +363,7 @@ haxelib help
 ```
 haxelib submit [project.zip]
 haxelib submit detox.zip
-haxelib sumbit
+haxelib submit
 ```
 
 > Submits a zip package to Haxelib so other users can install it.


### PR DESCRIPTION
Location : https://lib.haxe.org/documentation/using-haxelib/
Detail : haxelib submit in the Development section.

thanks :)
