### PR TITLE
Avoid using system shell to start processes

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -1660,6 +1660,37 @@ class Main {
 	}
 	static var __haxeVersion:SemVer;
 
+	function createProcess(command:String, args:Array<String>)
+	{
+		var process = new Process(command, args);
+		
+		var waiting = true;
+
+		while (waiting)
+		{
+			try
+			{
+				Sys.println(process.stdout.readLine());
+			}
+			catch (e:haxe.io.Eof)
+			{
+				waiting = false;
+			}
+		}
+
+		var error = process.stderr.readAll().toString();
+		var result = process.exitCode();
+
+		if (error != "")
+		{
+			Sys.println(error);
+		}
+		
+		process.close();
+
+		return result;
+	}
+
 	function doRun( rep:String, project:String, version:String ) {
 		var pdir = rep + Data.safe(project);
 		if( !FileSystem.exists(pdir) )
@@ -1695,7 +1726,7 @@ class Main {
 		Sys.putEnv("HAXELIB_RUN", "1");
 		Sys.putEnv("HAXELIB_RUN_NAME", project);
 		var cmd = callArgs.shift();
- 		Sys.exit(Sys.command(cmd, callArgs));
+ 		Sys.exit(createProcess(cmd, callArgs));
 	}
 
 	function runScriptArgs(project:String, main:String, dependencies:Dependencies):Array<String> {


### PR DESCRIPTION
This relates to https://github.com/HaxeFoundation/haxe/issues/10389

This change allows Haxe's basic build tooling to be used even when the system shell is unavailable.

`Sys.command` runs processes through the system shell. The 2-argument form of `new Process`, on the other hand, starts processes without going through the shell.