### PR TITLE
Fix license

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,7 +1,7 @@
 {
 	"name": "haxelib",
 	"url" : "https://lib.haxe.org/documentation/",
-	"license": "GPL",
+	"license": "MIT",
 	"tags": ["haxelib", "core"],
 	"description": "The haxelib client",
 	"classPath": "src",


### PR DESCRIPTION
Fixes #534

License in `haxelib.json` now matches the license stated at the top of source files (which is MIT).