### PR TITLE
Minor CI test fixes

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -187,9 +187,14 @@ rclone:
         && rm rclone.zip
     SAVE ARTIFACT rclone-*/rclone
 
+package-haxelib:
+    LOCALLY
+    RUN if [ ! -e "package.zip" ]; then haxe package.hxml; fi
+
 haxelib-deps:
     FROM +devcontainer-base
     USER $USERNAME
+    BUILD +package-haxelib
     COPY --chown=$USER_UID:$USER_GID libs.hxml run.n package.zip .
     COPY --chown=$USER_UID:$USER_GID lib/record-macros lib/record-macros
     RUN mkdir -p haxelib_global

--- a/Earthfile
+++ b/Earthfile
@@ -57,6 +57,7 @@ devcontainer-base:
             tzdata \
             python3-pip \
             docker-ce \ # install docker engine for running +ci target
+            mercurial \
         && add-apt-repository ppa:git-core/ppa \
         && apt-get install -y git \
         && curl -sL https://deb.nodesource.com/setup_14.x | bash - \

--- a/Earthfile
+++ b/Earthfile
@@ -65,7 +65,7 @@ devcontainer-base:
         # the haxelib server code base is not Haxe 4 ready
         && add-apt-repository ppa:haxe/haxe3.4 \
         && add-apt-repository ppa:haxe/haxe4.2 \
-        && apt-get install -y neko haxe=1:4.2.* \
+        && apt-get install -y haxe=1:4.2.* \
         # Install mysql-client
         # https://github.com/docker-library/mysql/blob/master/5.7/Dockerfile.debian
         && echo 'deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-5.7' > /etc/apt/sources.list.d/mysql.list \
@@ -86,6 +86,14 @@ devcontainer-base:
         && apt-get autoremove -y \
         && apt-get clean -y \
         && rm -rf /var/lib/apt/lists/*
+
+    RUN curl https://build.haxe.org/builds/neko/linux64/neko_latest.tar.gz > neko_latest.tar.gz
+    RUN mkdir -p out
+    RUN tar -xf neko_latest.tar.gz -C out
+    RUN mv -f out/neko-*-linux64/neko /usr/bin/neko
+    RUN mv -f out/neko-*-linux64/libneko.so.*.*.* /usr/lib/libneko.so
+    RUN mkdir -p /usr/lib/neko/
+    RUN mv -f out/neko-*-linux64/*.ndll /usr/lib/neko/
 
     ENV YARN_CACHE_FOLDER=/yarn
     RUN mkdir -m 777 "$YARN_CACHE_FOLDER"

--- a/Earthfile
+++ b/Earthfile
@@ -102,7 +102,7 @@ devcontainer-base:
     # Switch back to dialog for any ad-hoc use of apt-get
     ENV DEBIAN_FRONTEND=
 
-    # Setting the ENTRYPOINT to docker-init.sh will configure non-root access 
+    # Setting the ENTRYPOINT to docker-init.sh will configure non-root access
     # to the Docker socket. The script will also execute CMD as needed.
     ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
     CMD [ "sleep", "infinity" ]
@@ -493,7 +493,7 @@ ci-tests:
 ci-images:
     ARG --required GIT_REF_NAME
     ARG --required GIT_SHA
-    BUILD +devcontainer \ 
+    BUILD +devcontainer \
         --IMAGE_CACHE="$DEVCONTAINER_IMAGE_NAME_DEFAULT:$GIT_REF_NAME" \
         --IMAGE_TAG="$GIT_REF_NAME" \
         --IMAGE_TAG="$GIT_SHA" \

--- a/Earthfile
+++ b/Earthfile
@@ -182,10 +182,11 @@ rclone:
 haxelib-deps:
     FROM +devcontainer-base
     USER $USERNAME
-    COPY --chown=$USER_UID:$USER_GID libs.hxml run.n .
+    COPY --chown=$USER_UID:$USER_GID libs.hxml run.n package.zip .
     COPY --chown=$USER_UID:$USER_GID lib/record-macros lib/record-macros
     RUN mkdir -p haxelib_global
-    RUN haxelib setup haxelib_global
+    RUN neko run.n setup haxelib_global
+    RUN neko run.n install package.zip
     RUN haxe libs.hxml && rm haxelib_global/*.zip
     COPY github.com/andyli/aws-sdk-neko:0852144508e55c1d28ff7425a59ddf6f1758240a+package-zip/aws-sdk-neko.zip /tmp/aws-sdk-neko.zip
     RUN haxelib install /tmp/aws-sdk-neko.zip && rm /tmp/aws-sdk-neko.zip


### PR DESCRIPTION
- Install Mercurial so related tests can run
- Install the new haxelib package before running integration tests so they run with the new haxelib version (instead of testing the system installed one)
- Install nightly neko build