### PR TITLE
Implement switch aliases

### DIFF
--- a/src/haxelib/client/Args.hx
+++ b/src/haxelib/client/Args.hx
@@ -85,7 +85,7 @@ enum abstract Flag(String) to String {
 	final System = "system";
 	final SkipDependencies = "skip-dependencies";
 	// hidden
-	final NoTimeout = "notimeout";
+	final NoTimeout = "no-timeout";
 
 	public static final MUTUALLY_EXCLUSIVE = [[Quiet, Debug], [Always, Never]];
 
@@ -95,9 +95,16 @@ enum abstract Flag(String) to String {
 	**/
 	public static final PRIORITY = [System, Debug, Global];
 
+	static final ALIASES = ["notimeout" => NoTimeout];
+
 	static final FLAGS = Util.getValues(Flag);
 
 	public static function ofString(str:String):Null<Flag> {
+		// first check aliases
+		final alias = ALIASES.get(str);
+		if (alias != null)
+			return alias;
+
 		for (flag in FLAGS) {
 			if ((flag:String) == str)
 				return flag;
@@ -108,11 +115,18 @@ enum abstract Flag(String) to String {
 }
 
 enum abstract Option(String) to String {
-	final Remote = "R";
+	final Remote = "remote";
+
+	static final ALIASES = ["R" => Remote];
 
 	static final OPTIONS = Util.getValues(Option);
 
 	public static function ofString(str:String):Null<Option> {
+		// first check aliases
+		final alias = ALIASES.get(str);
+		if (alias != null)
+			return alias;
+
 		for (option in OPTIONS) {
 			if ((option:String) == str)
 				return option;

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -282,7 +282,7 @@ class Main {
 				+ "You can also setup the proxy with 'haxelib proxy'.\n"
 				+ haxe.CallStack.toString(haxe.CallStack.exceptionStack());
 			case "Blocked":
-				"Http connection timeout. Try running 'haxelib --notimeout <command>' to disable timeout";
+				"Http connection timeout. Try running 'haxelib --no-timeout <command>' to disable timeout";
 			case "std@get_cwd":
 				"Current working directory is unavailable";
 			case _:

--- a/src/haxelib/client/Util.hx
+++ b/src/haxelib/client/Util.hx
@@ -3,27 +3,120 @@ package haxelib.client;
 #if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
+import haxe.macro.Expr.Field;
 
 using haxe.macro.Tools;
 #end
 
 using StringTools;
+using Lambda;
 
-macro function getValues(typePath:Expr):Expr {
-	final type = Context.getType(typePath.toString());
+#if macro
+
+private function getValueArray(fields:Array<Field>):Expr {
+	final type = Context.getLocalClass().get();
 
 	// Switch on the type and check if it's an abstract with @:enum metadata
-	switch (type.follow()) {
-		case TAbstract(_.get() => ab, _) if (ab.meta.has(":enum")):
-			final valueExprs = [];
-			for (field in ab.impl.get().statics.get()) {
-				if (field.meta.has(":enum") && field.meta.has(":impl")) {
-					final fieldName = field.name;
-					valueExprs.push(macro $typePath.$fieldName);
-				}
-			}
-			return macro $a{valueExprs};
-		default:
-			throw new Error(type.toString() + " should be enum abstract", typePath.pos);
+	final valueExprs = [];
+	for (field in fields) {
+		switch field {
+			case {kind: FVar(_), access:access} if (!access.contains(AStatic)):
+				final fieldName = field.name;
+				valueExprs.push(macro $i{type.name}.$fieldName);
+			default:
+		}
 	}
+	return macro $a{valueExprs};
+}
+
+private function generateAliasMaps(fields:Array<Field>):{aliasesByName:Array<Expr>, namesByAlias:Array<Expr>} {
+	final aliasesByName = [];
+	final namesByAlias = [];
+
+	for (field in fields) {
+		if (field.meta == null)
+			continue;
+		final aliasMeta = field.meta.find((meta) -> meta.name == ":alias");
+		if (aliasMeta == null)
+			continue;
+		final aliases = [];
+		for (alias in aliasMeta.params) {
+			final alias = switch alias.expr {
+				case EConst(CString(s)): s;
+				default: throw new Error("Invalid alias type", field.pos);
+			}
+			aliases.push(alias);
+			namesByAlias.push(macro $v{alias} => $i{field.name});
+		}
+		aliasesByName.push(macro $i{field.name} => $v{aliases});
+	}
+	return { aliasesByName: aliasesByName, namesByAlias: namesByAlias };
+}
+
+function addStaticField(fields:Array<Field>,name:String, kind:FieldType, ?doc:String, isPublic = false)
+	fields.push({
+		name: name,
+		access: isPublic ? [AStatic, APublic] : [AStatic],
+		doc: doc,
+		kind: kind,
+		pos: Context.currentPos()
+	});
+
+#end
+
+private final ofString = macro {
+	for (value in VALUES) {
+		if ((value:String) == str)
+			return value;
+	}
+	return null;
+};
+private final ofStringWithAliases = macro {
+	// first check aliases
+	final alias = NAMES_BY_ALIAS[str];
+	if (alias != null)
+		return alias;
+	${ofString}
+};
+
+macro function buildArgType():Array<Field> {
+	final type = Context.getLocalType();
+
+	final abstractType = switch (type.getClass()) {
+		case {kind: KAbstractImpl(_.get() => ab)} if (ab.meta.has(":enum")):
+			ab;
+		case {name: name}:
+			throw new Error(name + " should be enum abstract", Context.currentPos());
+	}
+
+	final abstractPath = TPath({name: abstractType.name, pack: abstractType.pack});
+
+	final fields = Context.getBuildFields();
+	addStaticField(fields, "VALUES", FVar(macro:Array<$abstractPath>, getValueArray(fields)));
+
+	final aliasData = generateAliasMaps(fields);
+
+	final hasAliases = !aliasData.aliasesByName.empty();
+	if (hasAliases) {
+		addStaticField(fields, "ALIASES_BY_NAME", FVar(macro:Map<$abstractPath, Array<String>>, macro $a{aliasData.aliasesByName}));
+		addStaticField(fields, "NAMES_BY_ALIAS", FVar(macro:Map<String, $abstractPath>, macro $a{aliasData.namesByAlias}));
+	}
+
+	final argName = abstractType.name.toLowerCase();
+
+	addStaticField(fields, "getAliases", FFun({
+		args: [{name: argName, type: macro:$abstractPath}],
+		expr: hasAliases ? macro { return ALIASES_BY_NAME[$i{argName}] ?? []; } : macro {return [];},
+		ret: macro: Array<String>
+	}), 'Returns array of aliases for `$argName`.', true);
+
+	addStaticField(fields, "ofString", FFun({
+			args: [{name: "str", type: macro: String}],
+			expr: hasAliases ? ofStringWithAliases : ofString,
+			ret: macro:$abstractPath
+		}),
+		'Returns `str` as an instance of `${abstractType.name}`. If it is invalid, returns `null`.', true
+	);
+
+	return fields;
 }

--- a/test/tests/TestArgs.hx
+++ b/test/tests/TestArgs.hx
@@ -7,7 +7,7 @@ class TestArgs extends TestCase {
 
 	public function testPriorityFlags() {
 		final priorityFlags = Args.extractPriorityFlags([
-					"--debug", "--global", "--system", "--skip-dependencies", "--notimeout",
+					"--debug", "--global", "--system", "--skip-dependencies", "--no-timeout",
 					"--flat", "--always", "version"
 			]);
 		// priority
@@ -48,7 +48,7 @@ class TestArgs extends TestCase {
 
 	public function testFlags() {
 		final flags = Args.extractAll([
-			"--debug", "--global", "--system", "--skip-dependencies", "--notimeout",
+			"--debug", "--global", "--system", "--skip-dependencies", "--no-timeout",
 			"--flat", "--always", "version"
 		]).flags;
 		// given
@@ -89,14 +89,14 @@ class TestArgs extends TestCase {
 
 	public function testOptions() {
 		// one value given
-		final remote = Args.extractAll(["-R", "remotePath", "version"]).options[Remote];
+		final remote = Args.extractAll(["--remote", "remotePath", "version"]).options[Remote];
 		assertEquals("remotePath", remote);
 
 		// option without value should give error
-		assertFalse(areSwitchesValid(["version", "-R"]));
+		assertFalse(areSwitchesValid(["version", "--remote"]));
 
 		// when a normal option is repeated, should just give the last one.
-		final remote = Args.extractAll(["-R", "remotePath", "-R", "otherPath", "version"]).options[Remote];
+		final remote = Args.extractAll(["--remote", "remotePath", "--remote", "otherPath", "version"]).options[Remote];
 		assertEquals("otherPath", remote);
 
 		// not included
@@ -133,7 +133,7 @@ class TestArgs extends TestCase {
 		assertTrue(flags.contains(Debug));
 		assertTrue(flags.contains(SkipDependencies));
 		// options
-		final argsInfo = Args.extractAll(["-cwd", "path", "-R", "remotePath", "version"]);
+		final argsInfo = Args.extractAll(["-cwd", "path", "-remote", "remotePath", "version"]);
 
 		assertEquals("path", argsInfo.repeatedOptions[Cwd][0]);
 		assertEquals("remotePath", argsInfo.options[Remote]);
@@ -143,6 +143,13 @@ class TestArgs extends TestCase {
 
 		assertEquals("path", directories[0]);
 		assertEquals("otherPath", directories[1]);
+	}
+
+	public function testAliases() {
+		final argsInfo = Args.extractAll(["-R", "remotePath", "--notimeout", "version"]);
+
+		assertEquals("remotePath", argsInfo.options[Remote]);
+		assertTrue(argsInfo.flags.contains(NoTimeout));
 	}
 
 	public function testCommands() {

--- a/www/documentation-files/using-haxelib.md
+++ b/www/documentation-files/using-haxelib.md
@@ -66,7 +66,7 @@ The following commands are available:
     <li><a href="#never">--never</a></li>
     <li><a href="#global">--global</a></li>
     <li><a href="#skip-dependencies">--skip-dependencies</a></li>
-    <li><a href="#notimeout">--notimeout</a></li>
+    <li><a href="#no-timeout">--no-timeout</a></li>
   </ul>
 </div>
 
@@ -74,7 +74,7 @@ The following commands are available:
   <h4><a href="#parameters">Parameters</a></h4>
   <ul>
     <li><a href="#cwd">--cwd</a></li>
-    <li><a href="#R">-R</a></li>
+    <li><a href="#remote">--remote</a></li>
   </ul>
 </div>
 </div>
@@ -656,12 +656,12 @@ haxelib --skip-dependencies
 
 
 
-<a name="notimeout" class="anch"></a>
+<a name="no-timeout" class="anch"></a>
 
-### haxelib --notimeout
+### haxelib --no-timeout
 
 ```
-haxelib --notimeout
+haxelib --no-timeout
 ```
 
 > Remove timeout when connecting to the Haxelib server, downloading or [submitting](#submit) a library.
@@ -691,11 +691,12 @@ haxelib --cwd [dir]
 
 
 
-<a name="R" class="anch"></a>
+<a name="remote" class="anch"></a>
 
-### haxelib -R
+### haxelib --remote
 
 ```
+haxelib --remote [host:port[/dir]]
 haxelib -R [host:port[/dir]]
 ```
 
@@ -716,7 +717,7 @@ If `HAXELIB_NO_SSL` is set to `1` or `true`, then haxelib client will use http i
 ## HAXELIB_REMOTE
 
 `HAXELIB_REMOTE` may contain a url to a custom Haxelib server instead of `https://lib.haxe.org/`.
-However, if <a href="#R">-R</a> command line argument is provided, then `HAXELIB_REMOTE` is ignored.
+However, if <a href="#remote">--remote</a> command line argument is provided, then `HAXELIB_REMOTE` is ignored.
 
 <a name="HAXELIB_DEV_FILTER" class="anch"></a>
 


### PR DESCRIPTION
`-R` only had a single character version, this adds `--remote` as well.

`--notimeout` also is not consistent with `--skip-dependencies`, and the documentation was confused about this as well, so `--no-timeout` is now an alias.

These have been added to the `haxelib help` message as well, (`--remote` also shows its alias), along with `--cwd` which was also missing.