### PR TITLE
Add support for `hg` dependencies

### DIFF
--- a/src/haxelib/VersionData.hx
+++ b/src/haxelib/VersionData.hx
@@ -56,19 +56,17 @@ class VersionDataHelper {
 			return Haxelib(SemVer.ofString(versionInfo));
 		} catch (_:String) {}
 
-		try {
-			var data = getVcsData(versionInfo);
-			return VcsInstall(data.type, data.data);
-		} catch (e:String) {
+		var data = getVcsData(versionInfo);
+		if (data == null)
 			throw '$versionInfo is not a valid library version';
-		}
+		return VcsInstall(data.type, data.data);
 	}
 
 	static var vcsRegex = ~/^(git|hg)(?::(.+?)(?:#(?:([a-f0-9]{7,40})|(.+)))?)?$/;
 
-	static function getVcsData(s:String):{type:VcsID, data:VcsData} {
+	static function getVcsData(s:String):Null<{type:VcsID, data:VcsData}> {
 		if (!vcsRegex.match(s))
-			throw '$s is not valid';
+			return null;
 		var type = switch (vcsRegex.matched(1)) {
 			case Git:
 				Git;

--- a/src/haxelib/VersionData.hx
+++ b/src/haxelib/VersionData.hx
@@ -2,8 +2,8 @@ package haxelib;
 
 /** Abstract enum representing the types of Vcs systems that are supported. **/
 @:enum abstract VcsID(String) to String {
-	final Hg = "hg";
-	final Git = "git";
+	var Hg = "hg";
+	var Git = "git";
 
 	/** Returns `true` if `s` constitutes a valid VcsID **/
 	public static function isValid(s:String) {
@@ -25,23 +25,23 @@ package haxelib;
 @:structInit @:publicFields
 class VcsData {
 	/** url from which to install **/
-	final url:String;
+	var url:String;
 	/** Commit hash **/
 	@:optional
-	final ref:Null<String>;
+	var ref:Null<String>;
 	/** The git tag or mercurial revision **/
 	@:optional
-	final tag:Null<String>;
+	var tag:Null<String>;
 	/** Branch **/
 	@:optional
-	final branch:Null<String>;
+	var branch:Null<String>;
 	/**
 		Sub directory in which the root of the project is found.
 
 		Relative to project root
 	**/
 	@:optional
-	final subDir:Null<String>;
+	var subDir:Null<String>;
 }
 
 /** Data required to reproduce a library version **/
@@ -54,22 +54,22 @@ class VersionDataHelper {
 	public static function extractVersion(versionInfo:String):VersionData {
 		try {
 			return Haxelib(SemVer.ofString(versionInfo));
-		} catch (_) {}
+		} catch (_:String) {}
 
 		try {
-			final data = getVcsData(versionInfo);
+			var data = getVcsData(versionInfo);
 			return VcsInstall(data.type, data.data);
-		} catch (e) {
+		} catch (e:String) {
 			throw '$versionInfo is not a valid library version';
 		}
 	}
 
-	static final vcsRegex = ~/^(git|hg)(?::(.+?)(?:#(?:([a-f0-9]{7,40})|(.+)))?)?$/;
+	static var vcsRegex = ~/^(git|hg)(?::(.+?)(?:#(?:([a-f0-9]{7,40})|(.+)))?)?$/;
 
 	static function getVcsData(s:String):{type:VcsID, data:VcsData} {
 		if (!vcsRegex.match(s))
 			throw '$s is not valid';
-		final type = switch (vcsRegex.matched(1)) {
+		var type = switch (vcsRegex.matched(1)) {
 			case Git:
 				Git;
 			case _:

--- a/src/haxelib/VersionData.hx
+++ b/src/haxelib/VersionData.hx
@@ -1,0 +1,89 @@
+package haxelib;
+
+/** Abstract enum representing the types of Vcs systems that are supported. **/
+@:enum abstract VcsID(String) to String {
+	final Hg = "hg";
+	final Git = "git";
+
+	/** Returns `true` if `s` constitutes a valid VcsID **/
+	public static function isValid(s:String) {
+		return s == Hg || s == Git;
+	}
+
+	/** Returns `s` as a VcsID if it is valid, otherwise throws an error. **/
+	public static function ofString(s:String):VcsID {
+		if (s == Git)
+			return Git;
+		else if (s == Hg)
+			return Hg;
+		else
+			throw 'Invalid VscID $s';
+	}
+}
+
+/** Class containing repoducible git or hg library data. **/
+@:structInit @:publicFields
+class VcsData {
+	/** url from which to install **/
+	final url:String;
+	/** Commit hash **/
+	@:optional
+	final ref:Null<String>;
+	/** The git tag or mercurial revision **/
+	@:optional
+	final tag:Null<String>;
+	/** Branch **/
+	@:optional
+	final branch:Null<String>;
+	/**
+		Sub directory in which the root of the project is found.
+
+		Relative to project root
+	**/
+	@:optional
+	final subDir:Null<String>;
+}
+
+/** Data required to reproduce a library version **/
+enum VersionData {
+	Haxelib(version:SemVer);
+	VcsInstall(version:VcsID, vcsData:VcsData);
+}
+
+class VersionDataHelper {
+	public static function extractVersion(versionInfo:String):VersionData {
+		try {
+			return Haxelib(SemVer.ofString(versionInfo));
+		} catch (_) {}
+
+		try {
+			final data = getVcsData(versionInfo);
+			return VcsInstall(data.type, data.data);
+		} catch (e) {
+			throw '$versionInfo is not a valid library version';
+		}
+	}
+
+	static final vcsRegex = ~/^(git|hg)(?::(.+?)(?:#(?:([a-f0-9]{7,40})|(.+)))?)?$/;
+
+	static function getVcsData(s:String):{type:VcsID, data:VcsData} {
+		if (!vcsRegex.match(s))
+			throw '$s is not valid';
+		final type = switch (vcsRegex.matched(1)) {
+			case Git:
+				Git;
+			case _:
+				Hg;
+		}
+		return {
+			type: type,
+			data: {
+				url: vcsRegex.matched(2),
+				ref: vcsRegex.matched(3),
+				branch: vcsRegex.matched(4),
+				subDir: null,
+				tag: null
+			}
+		}
+	}
+}

--- a/src/haxelib/api/Connection.hx
+++ b/src/haxelib/api/Connection.hx
@@ -417,12 +417,12 @@ class Connection {
 	}
 
 	static function checkDependencies(dependencies:Dependencies) {
-		for (d in dependencies) {
-			final versions:Array<String> = getVersions(ProjectName.ofString(d.name));
-			if (d.version == "")
+		for (name => versionString in dependencies) {
+			final versions:Array<String> = getVersions(ProjectName.ofString(name));
+			if (versionString == "")
 				continue;
-			if (!versions.contains(d.version))
-				throw "Library " + d.name + " does not have version " + d.version;
+			if (!versions.contains(versionString))
+				throw "Library " + name + " does not have version " + versionString;
 		}
 	}
 

--- a/src/haxelib/api/LibFlagData.hx
+++ b/src/haxelib/api/LibFlagData.hx
@@ -2,11 +2,12 @@ package haxelib.api;
 
 import sys.io.File;
 
+import haxe.ds.Option;
+
 import haxelib.Data;
 
 import haxelib.api.Hxml;
-import haxelib.api.Vcs.VcsID;
-import haxelib.api.LibraryData.VcsData;
+import haxelib.VersionData.VersionDataHelper.extractVersion;
 
 using StringTools;
 
@@ -15,11 +16,6 @@ using StringTools;
 	that a Haxe `-lib` flag could hold, or a dependency string in a
 	`haxelib.json` file.
  **/
-enum LibFlagData {
-	None;
-	Haxelib(version:SemVer);
-	VcsInstall(version:VcsID, vcsData:VcsData);
-}
 
 private class LibParsingError extends haxe.Exception {}
 private final libDataEReg = ~/^(.+?)(?::(.*))?$/;
@@ -28,7 +24,7 @@ private final libDataEReg = ~/^(.+?)(?::(.*))?$/;
 	Extracts library info from a full flag,
 	i.e.: `name:1.2.3` or `name:git:url#hash`
 **/
-function extractFull(libFlag:String):{name:ProjectName, libFlagData:LibFlagData} {
+function extractFull(libFlag:String):{name:ProjectName, libFlagData:Option<VersionData>} {
 	if (!libDataEReg.match(libFlag))
 		throw '$libFlag is not a valid library flag';
 
@@ -38,50 +34,14 @@ function extractFull(libFlag:String):{name:ProjectName, libFlagData:LibFlagData}
 	if (versionInfo == null)
 		return {name: name, libFlagData: None};
 
-	return {name: name, libFlagData: extractVersion(versionInfo)};
+	return {name: name, libFlagData: Some(extractVersion(versionInfo))};
 }
 
-function extractFromDependencyString(str:DependencyVersion):LibFlagData {
+function extractFromDependencyString(str:DependencyVersion):Option<VersionData> {
 	if (str == "")
 		return None;
 
-	return extractVersion(str);
-}
-
-private function extractVersion(versionInfo:String):LibFlagData {
-	try {
-		return Haxelib(SemVer.ofString(versionInfo));
-	} catch (_) {}
-
-	try {
-		final data = getVcsData(versionInfo);
-		return VcsInstall(data.type, data.data);
-	} catch (e) {
-		throw '$versionInfo is not a valid library version';
-	}
-}
-
-private final vcsRegex = ~/^(git|hg)(?::(.+?)(?:#(?:([a-f0-9]{7,40})|(.+)))?)?$/;
-
-private function getVcsData(s:String):{type:VcsID, data:VcsData} {
-	if (!vcsRegex.match(s))
-		throw '$s is not valid';
-	final type = switch (vcsRegex.matched(1)) {
-		case Git:
-			Git;
-		case _:
-			Hg;
-	}
-	return {
-		type: type,
-		data: {
-			url: vcsRegex.matched(2),
-			ref: vcsRegex.matched(3),
-			branch: vcsRegex.matched(4),
-			subDir: null,
-			tag: null
-		}
-	}
+	return Some(extractVersion(str));
 }
 
 private final TARGETS = [
@@ -104,8 +64,8 @@ private final libraryFlagEReg = ~/^-(lib|L|-library)\b/;
 
 	Does not filter out repeated libs.
  **/
-function fromHxml(path:String):List<{name:ProjectName, data:LibFlagData, isTargetLib:Bool}> {
-	final libsData = new List<{name:ProjectName, data:LibFlagData, isTargetLib:Bool}>();
+function fromHxml(path:String):List<{name:ProjectName, data:Option<VersionData>, isTargetLib:Bool}> {
+	final libsData = new List<{name:ProjectName, data:Option<VersionData>, isTargetLib:Bool}>();
 
 	final lines = [path];
 
@@ -137,7 +97,7 @@ function fromHxml(path:String):List<{name:ProjectName, data:LibFlagData, isTarge
 				name: name,
 				data: switch (libDataEReg.matched(2)) {
 					case null: None;
-					case v: extractVersion(v);
+					case v: Some(extractVersion(v));
 				},
 				isTargetLib: false
 			});

--- a/src/haxelib/api/LibraryData.hx
+++ b/src/haxelib/api/LibraryData.hx
@@ -2,7 +2,7 @@ package haxelib.api;
 
 import haxe.DynamicAccess;
 
-import haxelib.api.Vcs.VcsID;
+import haxelib.VersionData;
 
 /** Exception thrown upon errors regarding library data, such as invalid versions. **/
 class LibraryDataException extends haxe.Exception {}
@@ -76,28 +76,5 @@ class VcsLibraryData implements ILibraryData {
 private final hashRegex = ~/^([a-f0-9]{7,40})$/;
 function isCommitHash(str:String)
 	return hashRegex.match(str);
-
-/** Class containing repoducible git or hg library data. **/
-@:structInit
-class VcsData {
-	/** url from which to install **/
-	public final url:String;
-	/** Commit hash **/
-	@:optional
-	public final ref:Null<String>;
-	/** The git tag or mercurial revision **/
-	@:optional
-	public final tag:Null<String>;
-	/** Branch **/
-	@:optional
-	public final branch:Null<String>;
-	/**
-		Sub directory in which the root of the project is found.
-
-		Relative to project root
-	**/
-	@:optional
-	public final subDir:Null<String>;
-}
 
 typedef LockFormat = DynamicAccess<LibraryData>;

--- a/src/haxelib/api/Repository.hx
+++ b/src/haxelib/api/Repository.hx
@@ -3,6 +3,7 @@ package haxelib.api;
 import sys.FileSystem;
 import sys.io.File;
 
+import haxelib.VersionData.VcsID;
 import haxelib.api.RepoManager;
 import haxelib.api.LibraryData;
 
@@ -97,7 +98,7 @@ class Repository {
 	/** Returns information on currently installed versions for project `name` **/
 	public function getProjectInstallationInfo(name:ProjectName):{versions: Array<Version>, devPath:String} {
 		final semVers:Array<SemVer> = [];
-		final others:Array<Vcs.VcsID> = [];
+		final others:Array<VcsID> = [];
 		final root = getProjectRootPath(name);
 
 		for (sub in FileSystem.readDirectory(root)) {
@@ -110,8 +111,8 @@ class Repository {
 				final semVer = SemVer.ofString(version);
 				semVers.push(semVer);
 			} catch(e:haxe.Exception) {
-				if (Vcs.VcsID.isValid(version))
-					others.push(Vcs.VcsID.ofString(version));
+				if (VcsID.isValid(version))
+					others.push(VcsID.ofString(version));
 			}
 		}
 		if (semVers.length != 0)
@@ -363,7 +364,7 @@ class Repository {
 		final versionDir:String =
 			switch version {
 				case v if (SemVer.isValid(v)): v;
-				case (try Vcs.VcsID.ofString(_) catch(_) null) => vcs if (vcs != null):
+				case (try VcsID.ofString(_) catch(_) null) => vcs if (vcs != null):
 					Vcs.getDirectoryFor(vcs);
 				//case _: throw 'Unknown library version: $version'; // we shouldn't get here
 				case custom: custom;

--- a/src/haxelib/api/Scope.hx
+++ b/src/haxelib/api/Scope.hx
@@ -1,5 +1,6 @@
 package haxelib.api;
 
+import haxelib.VersionData;
 import haxelib.api.LibraryData;
 import haxelib.api.ScriptRunner;
 
@@ -94,7 +95,7 @@ abstract class Scope {
 
 		Requires that the library is already installed.
 	**/
-	public abstract function setVcsVersion(library:ProjectName, vcsVersion:Vcs.VcsID, ?data:VcsData):Void;
+	public abstract function setVcsVersion(library:ProjectName, vcsVersion:VcsID, ?data:VcsData):Void;
 
 	/** Returns whether `library` is currently installed in this scope (ignoring overrides). **/
 	public abstract function isLibraryInstalled(library:ProjectName):Bool;

--- a/src/haxelib/api/Vcs.hx
+++ b/src/haxelib/api/Vcs.hx
@@ -22,6 +22,7 @@
 package haxelib.api;
 
 import sys.FileSystem;
+import haxelib.VersionData.VcsID;
 using haxelib.api.Vcs;
 
 interface IVcs {
@@ -60,27 +61,6 @@ interface IVcs {
 		Returns `true` if update successful.
 	**/
 	function update(?confirm:()->Bool, ?debugLog:(msg:String)->Void, ?summaryLog:(msg:String)->Void):Bool;
-}
-
-/** Abstract enum representing the types of Vcs systems that are supported. **/
-@:enum abstract VcsID(String) to String {
-	final Hg = "hg";
-	final Git = "git";
-
-	/** Returns `true` if `s` constitutes a valid VcsID **/
-	public static function isValid(s:String) {
-		return s == Hg || s == Git;
-	}
-
-	/** Returns `s` as a VcsID if it is valid, otherwise throws an error. **/
-	public static function ofString(s:String):VcsID {
-		if (s == Git)
-			return Git;
-		else if (s == Hg)
-			return Hg;
-		else
-			throw 'Invalid VscID $s';
-	}
 }
 
 /** Enum representing errors that can be thrown during a vcs operation. **/

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -28,7 +28,7 @@ import sys.FileSystem;
 import sys.io.File;
 
 import haxelib.api.*;
-import haxelib.api.Vcs;
+import haxelib.VersionData.VcsID;
 import haxelib.api.LibraryData;
 
 import haxelib.client.Args;

--- a/test/HaxelibTests.hx
+++ b/test/HaxelibTests.hx
@@ -66,6 +66,7 @@ class HaxelibTests {
 		r.add(new TestVcsNotFound());
 		r.add(new TestSemVer());
 		r.add(new TestData());
+		r.add(new TestVersionData());
 		r.add(new TestRemoveSymlinks());
 		r.add(new TestRemoveSymlinksBroken());
 		r.add(new TestInstaller());

--- a/test/libraries/libFooHgDep/foo/Foo.hx
+++ b/test/libraries/libFooHgDep/foo/Foo.hx
@@ -1,0 +1,9 @@
+package foo;
+
+class Foo {
+
+	public function new() {
+		trace("new Foo");
+	}
+
+}

--- a/test/libraries/libFooHgDep/haxelib.json
+++ b/test/libraries/libFooHgDep/haxelib.json
@@ -1,0 +1,13 @@
+{
+	"name": "Foo",
+	"url" : "http://example.org",
+	"license": "GPL",
+	"tags": ["foo", "test"],
+	"description": "This project is an example of an haxelib project",
+	"version": "1.0.0",
+	"releasenote": "Initial release, everything is working correctly",
+	"dependencies": {
+		"Bar": "hg:./libraries/libBar"
+	},
+	"contributors": ["Foo"]
+}

--- a/test/tests/TestData.hx
+++ b/test/tests/TestData.hx
@@ -229,10 +229,14 @@ class TestData extends TestBase {
 		assertEquals(0, Data.readData(getJsonInfos({tags: "mytag"}), NoCheck).tags.length);
 
 		// Dependencies (optional)
-		inline function getFirstDependency(dependencies:Dynamic)
-			return Data.readData(getJsonInfos({dependencies: dependencies}), NoCheck).dependencies.toArray()[0];
+		function getFirstDependency(dependencies:Dynamic) {
+			final dependencies = Data.readData(getJsonInfos({dependencies: dependencies}), NoCheck).dependencies;
+			for (name => version in dependencies)
+				return {name: name, version:version};
+			return null;
+		}
 
-		assertEquals(0, Data.readData(getJsonInfos({dependencies: null}), NoCheck).dependencies.toArray().length);
+		assertEquals(0, Lambda.count(Data.readData(getJsonInfos({dependencies: null}), NoCheck).dependencies));
 		assertEquals("somelib", getFirstDependency({somelib: ""}).name);
 		assertEquals("", getFirstDependency({somelib: ""}).version);
 		assertEquals("1.3.0", getFirstDependency({somelib: "1.3.0"}).version);
@@ -240,11 +244,7 @@ class TestData extends TestBase {
 		assertEquals("", getFirstDependency({somelib: null}).version);
 		assertEquals("", getFirstDependency({somelib: 0}).version);
 		assertEquals("git", getFirstDependency({somelib: "git"}).version);
-
-		final gitDependency = getFirstDependency({somelib: "git:https://some.url#branch"});
-		assertEquals(Git, gitDependency.type);
-		assertEquals("https://some.url", gitDependency.url);
-		assertEquals("branch", gitDependency.branch);
+		assertEquals("git:https://some.url#branch", getFirstDependency({somelib: "git:https://some.url#branch"}).version);
 
 		// ReleaseNote
 		assertEquals("release", Data.readData(getJsonInfos({releasenote: "release"}), NoCheck).releasenote);

--- a/test/tests/TestGit.hx
+++ b/test/tests/TestGit.hx
@@ -1,7 +1,7 @@
 package tests;
 
 import sys.FileSystem;
-import haxelib.api.Vcs;
+import haxelib.VersionData.VcsID;
 
 class TestGit extends TestVcs {
 	static final REPO_PATH = 'test/repo/git';

--- a/test/tests/TestGlobalScope.hx
+++ b/test/tests/TestGlobalScope.hx
@@ -6,7 +6,7 @@ import tests.util.DirectoryState;
 
 import haxelib.ProjectName;
 import haxelib.SemVer;
-import haxelib.api.Vcs;
+import haxelib.VersionData.VcsID;
 
 using haxe.io.Path;
 

--- a/test/tests/TestInstaller.hx
+++ b/test/tests/TestInstaller.hx
@@ -99,7 +99,7 @@ class TestInstaller extends TestBase {
 		final haxelibFile = File.read("haxelib.json", false);
 		final details = Data.readData(haxelibFile.readAll().toString(), NoCheck);
 		haxelibFile.close();
-		return details.dependencies.toArray()[0].name;
+		return details.dependencies.getNames()[0];
 	}
 
 	function checkLibrary(lib:String):Void {

--- a/test/tests/TestScope.hx
+++ b/test/tests/TestScope.hx
@@ -7,8 +7,8 @@ import tests.util.DirectoryState;
 
 import haxelib.ProjectName;
 import haxelib.SemVer;
+import haxelib.VersionData.VcsID;
 
-import haxelib.api.Vcs;
 import haxelib.api.LibraryData;
 import haxelib.api.Scope;
 import haxelib.api.RepoManager;

--- a/test/tests/TestVcs.hx
+++ b/test/tests/TestVcs.hx
@@ -5,6 +5,7 @@ import sys.FileSystem;
 import haxe.io.*;
 import haxe.unit.TestCase;
 
+import haxelib.VersionData.VcsID;
 import haxelib.api.Vcs;
 
 class TestVcs extends TestBase

--- a/test/tests/TestVersionData.hx
+++ b/test/tests/TestVersionData.hx
@@ -1,0 +1,68 @@
+package tests;
+
+import haxelib.SemVer;
+import haxelib.VersionData;
+import haxelib.VersionData.VersionDataHelper.extractVersion;
+
+class TestVersionData extends TestBase {
+	function testHaxelib() {
+		assertTrue(extractVersion("1.0.0").equals(Haxelib(SemVer.ofString("1.0.0"))));
+		assertTrue(extractVersion("1.0.0-beta").equals(Haxelib(SemVer.ofString("1.0.0-beta"))));
+	}
+
+	function assertVersionDataEquals(expected:VersionData, actual:VersionData) {
+		assertEquals(Std.string(expected), Std.string(actual));
+	}
+
+	function testGit() {
+		assertVersionDataEquals(extractVersion("git:https://some.url"), VcsInstall(VcsID.ofString("git"), {
+			url: "https://some.url",
+			branch: null,
+			ref: null,
+			tag: null,
+			subDir: null
+		}));
+
+		assertVersionDataEquals(extractVersion("git:https://some.url#branch"), VcsInstall(VcsID.ofString("git"), {
+			url: "https://some.url",
+			branch: "branch",
+			ref: null,
+			tag: null,
+			subDir: null
+		}));
+
+		assertVersionDataEquals(extractVersion("git:https://some.url#abcdef0"), VcsInstall(VcsID.ofString("git"), {
+			url: "https://some.url",
+			branch: null,
+			ref: "abcdef0",
+			tag: null,
+			subDir: null
+		}));
+	}
+
+	function testMercurial() {
+		assertVersionDataEquals(extractVersion("hg:https://some.url"), VcsInstall(VcsID.ofString("hg"), {
+			url: "https://some.url",
+			branch: null,
+			ref: null,
+			tag: null,
+			subDir: null
+		}));
+
+		assertVersionDataEquals(extractVersion("hg:https://some.url#branch"), VcsInstall(VcsID.ofString("hg"), {
+			url: "https://some.url",
+			branch: "branch",
+			ref: null,
+			tag: null,
+			subDir: null
+		}));
+
+		assertVersionDataEquals(extractVersion("hg:https://some.url#abcdef0"), VcsInstall(VcsID.ofString("hg"), {
+			url: "https://some.url",
+			branch: null,
+			ref: "abcdef0",
+			tag: null,
+			subDir: null
+		}));
+	}
+}

--- a/test/tests/integration/TestInstall.hx
+++ b/test/tests/integration/TestInstall.hx
@@ -5,6 +5,7 @@ import tests.util.Vcs;
 class TestInstall extends IntegrationTests {
 
 	final gitLibPath = "libraries/libBar";
+	final hgLibPath = "libraries/libBar";
 
 	override function setup(){
 		super.setup();
@@ -24,6 +25,7 @@ class TestInstall extends IntegrationTests {
 
 	override function tearDown() {
 		resetGitRepo(gitLibPath);
+		resetHgRepo(hgLibPath);
 		super.tearDown();
 	}
 
@@ -224,6 +226,24 @@ class TestInstall extends IntegrationTests {
 		final r = haxelib(["list", "Bar"]).result();
 		assertTrue(r.out.indexOf("Bar") >= 0);
 		assertTrue(r.out.indexOf("[git]") >= 0);
+		assertSuccess(r);
+	}
+
+	function testLocalWithHgDependency() {
+		// prepare hg dependency
+		makeHgRepo(hgLibPath);
+
+		final r = haxelib(["install", "libraries/libFooHgDep.zip"]).result();
+		assertSuccess(r);
+
+		final r = haxelib(["list", "Foo"]).result();
+		assertTrue(r.out.indexOf("Foo") >= 0);
+		assertTrue(r.out.indexOf("[1.0.0]") >= 0);
+		assertSuccess(r);
+
+		final r = haxelib(["list", "Bar"]).result();
+		assertTrue(r.out.indexOf("Bar") >= 0);
+		assertTrue(r.out.indexOf("[hg]") >= 0);
 		assertSuccess(r);
 	}
 }

--- a/test/tests/integration/TestSet.hx
+++ b/test/tests/integration/TestSet.hx
@@ -5,6 +5,8 @@ import sys.FileSystem;
 import tests.util.Vcs;
 
 class TestSet extends IntegrationTests {
+	final gitLibPath = "libraries/libBar";
+	final hgLibPath = "libraries/libBar";
 
 	override function setup() {
 		super.setup();
@@ -20,7 +22,8 @@ class TestSet extends IntegrationTests {
 	}
 
 	override function tearDown() {
-		resetGitRepo('libraries/libBar');
+		resetGitRepo(gitLibPath);
+		resetHgRepo(hgLibPath);
 
 		super.tearDown();
 	}
@@ -157,16 +160,22 @@ class TestSet extends IntegrationTests {
 	}
 
 	function testGit() {
-		final gitPath = '${projectRoot}test/libraries/libBar';
+		makeGitRepo(gitLibPath);
+		templateVcs("git", gitLibPath);
+	}
 
-		makeGitRepo(gitPath);
+	function testHg() {
+		makeHgRepo(hgLibPath);
+		templateVcs("hg", hgLibPath);
+	}
 
-		final r = haxelib(["git", "Bar", gitPath]).result();
+	function templateVcs(type:String, repoPath:String) {
+		final r = haxelib([type, "Bar", repoPath]).result();
 		assertSuccess(r);
 
 		final r = haxelib(["list", "Bar"]).result();
 		assertSuccess(r);
-		assertTrue(r.out.indexOf("[git]") >= 0);
+		assertTrue(r.out.indexOf('[$type]') >= 0);
 
 		final r = haxelib(["install", "Bar"]).result();
 		assertSuccess(r);
@@ -174,15 +183,15 @@ class TestSet extends IntegrationTests {
 		final r = haxelib(["list", "Bar"]).result();
 		assertSuccess(r);
 		assertTrue(r.out.indexOf("[2.0.0]") >= 0);
-		assertTrue(r.out.indexOf("git") >= 0);
+		assertTrue(r.out.indexOf(type) >= 0);
 
-		final r = haxelib(["set", "Bar", "git"]).result();
+		final r = haxelib(["set", "Bar", type]).result();
 		assertSuccess(r);
 
 		final r = haxelib(["list", "Bar"]).result();
 		assertSuccess(r);
 		assertTrue(r.out.indexOf("2.0.0") >= 0);
-		assertTrue(r.out.indexOf("[git]") >= 0);
+		assertTrue(r.out.indexOf('[$type]') >= 0);
 	}
 
 	function testInvalidVersion() {

--- a/test/tests/integration/TestUpdate.hx
+++ b/test/tests/integration/TestUpdate.hx
@@ -5,14 +5,11 @@ import tests.util.Vcs;
 class TestUpdate extends IntegrationTests {
 
 	final gitLibPath = 'libraries/libBar';
-
-	override function setup() {
-		super.setup();
-		makeGitRepo(gitLibPath);
-	}
+	final hgLibPath = 'libraries/libBar';
 
 	override function tearDown() {
 		resetGitRepo(gitLibPath);
+		resetHgRepo(hgLibPath);
 		super.tearDown();
 	}
 
@@ -123,7 +120,8 @@ class TestUpdate extends IntegrationTests {
 		{
 			final r = haxelib(["update", "bar"]).result();
 			assertSuccess(r);
-			assertFalse("Library Bar is already up to date\n" == r.out);
+			assertTrue(r.out.contains("Current version is now 2.0.0"));
+			assertFalse("Library Bar is already up to date" == r.out.trim());
 		}
 
 		{
@@ -146,60 +144,52 @@ class TestUpdate extends IntegrationTests {
 	}
 
 	function testUpdatingWithGitVersion():Void {
+		makeGitRepo(gitLibPath);
+		templateTestWithVcsVersion("git", gitLibPath);
+	}
+
+	function testUpdatingWithHgVersion():Void {
+		makeHgRepo(hgLibPath);
+		templateTestWithVcsVersion("hg", hgLibPath);
+	}
+
+	function templateTestWithVcsVersion(type:String, repoPath:String) {
 		// #364
-		{
-			final r = haxelib(["git", "Bar", gitLibPath]).result();
-			assertSuccess(r);
-		}
+		final r = haxelib([type, "Bar", repoPath]).result();
+		assertSuccess(r);
 
-		{
-			final r = haxelib(["update", "Bar"]).result();
-			assertSuccess(r);
-			assertTrue(r.out.indexOf("Library Bar git repository is already up to date") >= 0);
+		final r = haxelib(["update", "Bar"]).result();
+		assertSuccess(r);
+		assertTrue(r.out.indexOf('Library Bar $type repository is already up to date') >= 0);
 
-			// Don't show update message if vcs lib was already up to date
-			assertTrue(r.out.indexOf("Bar was updated") < 0);
-		}
+		// Don't show update message if vcs lib was already up to date
+		assertTrue(r.out.indexOf("Bar was updated") < 0);
 
-		{
-			final r = haxelib(["register", bar.user, bar.email, bar.fullname, bar.pw, bar.pw]).result();
-			assertSuccess(r);
-		}
+		final r = haxelib(["register", bar.user, bar.email, bar.fullname, bar.pw, bar.pw]).result();
+		assertSuccess(r);
 
-		{
-			final r = haxelib(["submit", Path.join([IntegrationTests.projectRoot, "test/libraries/libBar.zip"]), bar.pw]).result();
-			assertSuccess(r);
-		}
+		final r = haxelib(["submit", Path.join([IntegrationTests.projectRoot, "test/libraries/libBar.zip"]), bar.pw]).result();
+		assertSuccess(r);
 
-		{
-			final r = haxelib(["install", "Bar"]).result();
-			assertSuccess(r);
-		}
+		final r = haxelib(["install", "Bar"]).result();
+		assertSuccess(r);
 
-		{
-			final r = haxelib(["list", "Bar"]).result();
-			assertSuccess(r);
-			assertTrue(r.out.indexOf("[1.0.0]") >= 0);
-			assertTrue(r.out.indexOf("git") >= 0);
-		}
+		final r = haxelib(["list", "Bar"]).result();
+		assertSuccess(r);
+		assertTrue(r.out.indexOf("[1.0.0]") >= 0);
+		assertTrue(r.out.indexOf(type) >= 0);
 
-		{
-			final r = haxelib(["submit", Path.join([IntegrationTests.projectRoot, "test/libraries/libBar2.zip"]), bar.pw]).result();
-			assertSuccess(r);
-		}
+		final r = haxelib(["submit", Path.join([IntegrationTests.projectRoot, "test/libraries/libBar2.zip"]), bar.pw]).result();
+		assertSuccess(r);
 
-		{
-			final r = haxelib(["update", "Bar"]).result();
-			assertSuccess(r);
-			assertTrue(r.out.indexOf("Library Bar git repository is already up to date") < 0);
-		}
+		final r = haxelib(["update", "Bar"]).result();
+		assertSuccess(r);
+		assertTrue(r.out.indexOf('Library Bar $type repository is already up to date') < 0);
 
-		{
-			final r = haxelib(["list", "Bar"]).result();
-			assertSuccess(r);
-			assertTrue(r.out.indexOf("[2.0.0]") >= 0);
-			assertTrue(r.out.indexOf("1.0.0") >= 0);
-			assertTrue(r.out.indexOf("git") >= 0);
-		}
+		final r = haxelib(["list", "Bar"]).result();
+		assertSuccess(r);
+		assertTrue(r.out.indexOf("[2.0.0]") >= 0);
+		assertTrue(r.out.indexOf("1.0.0") >= 0);
+		assertTrue(r.out.indexOf(type) >= 0);
 	}
 }


### PR DESCRIPTION
Merge code which parses `git:https://some.url` and `somelib:git:https://some.url`, thus allowing for mercurial dependencies in `haxelib.json` files (this was missing for some reason). Includes appropriate testing.