### PR TITLE
Show allowed licenses if license is invalid

### DIFF
--- a/src/haxelib/Validator.hx
+++ b/src/haxelib/Validator.hx
@@ -148,7 +148,11 @@ class Validator {
 						macro @:pos(pos) $p{(name+'.'+f.name).split('.')}
 					];
 
-					macro if (!Lambda.has($a { options }, $IARG)) throw 'Invalid value ' + $IARG + ' for ' + $v { a.name };
+					macro {
+						var allowed = $a { options };
+						if (!Lambda.has(allowed, $IARG))
+							throw 'Invalid value `' + $IARG + '` for ' + $v { a.name } + '. Allowed values: ' + allowed.join(', ');
+					};
 
 				case TAbstract(_.get() => a, _):
 

--- a/test/tests/integration/TestSubmit.hx
+++ b/test/tests/integration/TestSubmit.hx
@@ -91,7 +91,7 @@ class TestSubmit extends IntegrationTests {
 
 		final r = haxelib(["submit", Path.join([IntegrationTests.projectRoot, "test/libraries/libInvalidLicense.zip"]), bar.pw]).result();
 		assertFail(r);
-		assertEquals("Error: Invalid value Unknown for License", r.err.trim());
+		assertEquals("Error: Invalid value `Unknown` for License. Allowed values: GPL, LGPL, MIT, BSD, Public, Apache", r.err.trim());
 
 		final r = haxelib(["search", "Bar"]).result();
 		// did not get submitted


### PR DESCRIPTION
`Error: Invalid value <blah blah> for License.` isn't a very useful error message.

Now shows the user the permitted values, as before:
```Error: Invalid value `<blah blah>` for License. Allowed values: GPL, LGPL, MIT, BSD, Public, Apache```