### PR TITLE
Make email addresses private

### DIFF
--- a/src/haxelib/server/Repo.hx
+++ b/src/haxelib/server/Repo.hx
@@ -105,7 +105,7 @@ class Repo implements SiteApi {
 		return {
 			name : u.name,
 			fullname : u.fullname,
-			email : u.email,
+			email : "(private)",
 			projects : projects,
 		};
 	}

--- a/test/tests/integration/TestUser.hx
+++ b/test/tests/integration/TestUser.hx
@@ -13,7 +13,8 @@ class TestUser extends IntegrationTests {
 
 			assertTrue(r.out.indexOf("Bar") >= 0);
 
-			assertTrue(r.out.indexOf(bar.email) >= 0);
+			assertTrue(r.out.indexOf(bar.email) == -1);
+			assertTrue(r.out.indexOf("(private)") >= 0);
 			assertTrue(r.out.indexOf(bar.fullname) >= 0);
 			assertTrue(r.out.indexOf(bar.pw) == -1);
 		}
@@ -29,7 +30,8 @@ class TestUser extends IntegrationTests {
 
 			assertTrue(r.out.indexOf("Bar") >= 0);
 
-			assertTrue(r.out.indexOf(bar.email) >= 0);
+			assertTrue(r.out.indexOf(bar.email) == -1);
+			assertTrue(r.out.indexOf("(private)") >= 0);
 			assertTrue(r.out.indexOf(bar.fullname) >= 0);
 			assertTrue(r.out.indexOf(bar.pw) == -1);
 


### PR DESCRIPTION
Addresses #567. For now, just by making all email addresses hidden (will now show "(private)" when running `haxelib user`). In the future, we could optionally allow users to show their emails. After #564, we could also have better client side handling for displaying information for a user who doesn't have their email displayed publicly.