### PR TITLE
fix(schema): Add title to schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Haxelib project configuration",
 	"description": "A haxelib project",
 	"type": "object",
 	"properties": {


### PR DESCRIPTION
As a part of restructuring in the SchemaStore repository, I noticed that a `title` property was defined in [the schemastore haxelib.json](https://github.com/SchemaStore/schemastore/blob/fa3112f1fccd1a50cf9242342d154a4103972c5a/src/schemas/json/haxelib.json), but not in this one. I thought it would be good to add it here to ensure that no information is lost during the restructuring (it will be removed).