### PR TITLE
Setup legacy server automatically

### DIFF
--- a/src/legacyhaxelib/Site.hx
+++ b/src/legacyhaxelib/Site.hx
@@ -36,9 +36,14 @@ class Site {
 	public static var REP_DIR = CWD+"../"+Data.REPOSITORY;
 
 	static function initDatabase() {
+		var alreadyExists = sys.FileSystem.exists(DB_FILE);
 		db = neko.db.Sqlite.open(DB_FILE);
 		neko.db.Manager.cnx = db;
 		neko.db.Manager.initialize();
+
+		if (!alreadyExists) {
+			SiteDb.create(db);
+		}
 	}
 
 	static function run() {


### PR DESCRIPTION
This runs the setup for the legacy server automatically, which prevents the need for manual setup during testing. Reverts to a similar state to #575, now that the live server db path has been fixed.