### PR TITLE
Use local share directory on unix like systems

### DIFF
--- a/src/haxelib/api/RepoManager.hx
+++ b/src/haxelib/api/RepoManager.hx
@@ -250,7 +250,14 @@ class RepoManager {
 		if (IS_WINDOWS)
 			return getWindowsDefaultGlobalPath();
 
-		// TODO `lib/` is for binaries, see if we can move all of these to `share/`
+		final dataHome = Sys.getEnv("XDG_DATA_HOME");
+		if (dataHome != null) {
+			return dataHome + '/haxe/$REPO_DIR/';
+		}
+		final home = Sys.getEnv("HOME");
+		if (home != null) {
+			return home + '/.local/share/haxe/$REPO_DIR/';
+		}
 		return if (FileSystem.exists("/usr/share/haxe/")) // for Debian
 			'/usr/share/haxe/$REPO_DIR/'
 		else if (Sys.systemName() == "Mac") // for newer OSX, where /usr/lib is not writable


### PR DESCRIPTION
Avoids permission issues when setting up haxelib, because the previous default paths required root privileges.

This won't change current setups, just the default path for new users.