### PR TITLE
Move password hashing to server side

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -379,13 +379,21 @@ haxelib-server-tasks:
     RUN haxe server_tasks.hxml
     SAVE ARTIFACT www/tasks.n
 
+haxelib-server-api-3.0:
+    FROM +haxelib-server-builder
+    COPY server_api_3.0.hxml server_each.hxml .
+    COPY src src
+    COPY hx3compat hx3compat
+    RUN haxe server_api_3.0.hxml
+    SAVE ARTIFACT www/api/3.0/index.n
+
 haxelib-server-api:
     FROM +haxelib-server-builder
     COPY server_api.hxml server_each.hxml .
     COPY src src
     COPY hx3compat hx3compat
     RUN haxe server_api.hxml
-    SAVE ARTIFACT www/api/3.0/index.n
+    SAVE ARTIFACT www/api/4.0/index.n
 
 haxelib-server-www-js:
     FROM +devcontainer-base
@@ -469,7 +477,8 @@ haxelib-server:
     COPY +haxelib-server-website-highlighter/highlighter.js www/js/highlighter.js
     COPY +haxelib-server-website/index.n www/index.n
     COPY +haxelib-server-tasks/tasks.n www/tasks.n
-    COPY +haxelib-server-api/index.n www/api/3.0/index.n
+    COPY +haxelib-server-api-3.0/index.n www/api/3.0/index.n
+    COPY +haxelib-server-api/index.n www/api/4.0/index.n
 
     EXPOSE 80
 

--- a/server_api_3.0.hxml
+++ b/server_api_3.0.hxml
@@ -1,8 +1,8 @@
 -cp src
--neko www/api/4.0/index.n
+-neko www/api/3.0/index.n
 -main haxelib.server.Repo
 -lib aws-sdk-neko
 -lib record-macros
 -dce no
 -D haxelib-api
--D haxelib-api-version=4.0
+-D haxelib-api-version=3.0

--- a/src/haxelib/Data.hx
+++ b/src/haxelib/Data.hx
@@ -201,6 +201,15 @@ class Data {
 	public static var JSON(default, null) = "haxelib.json";
 	/** The name of the file containing project documentation. **/
 	public static var DOCXML(default, null) = "haxedoc.xml";
+	/** The current haxelib server api version number. **/
+	public static var API_VERSION(default, null) =
+		#if (!haxelib_api_version || haxelib_api_version == "4.0")
+			"4.0";
+		#elseif (haxelib_api_version == "3.0")
+			"3.0";
+		#elseif haxelib_api_version
+			#error "`-D haxelib-api-version` has been set to an invalid value"
+		#end
 	/** The location of the repository in the haxelib server. **/
 	public static var REPOSITORY(default, null) = "files/3.0";
 	/** Regex matching alphanumeric strings, which can also include periods, dashes, or underscores. **/

--- a/src/haxelib/api/Connection.hx
+++ b/src/haxelib/api/Connection.hx
@@ -69,7 +69,7 @@ private class ConnectionData {
 			port: useSsl ? 443 : 80,
 			dir: "",
 			url: "index.n",
-			apiVersion: "3.0",
+			apiVersion: Data.API_VERSION,
 			useSsl: useSsl
 		};
 	}
@@ -95,7 +95,7 @@ private class ConnectionData {
 			port: port,
 			dir: haxe.io.Path.addTrailingSlash(r.matched(4)),
 			url: "index.n",
-			apiVersion: "3.0",
+			apiVersion: Data.API_VERSION,
 			useSsl: useSsl
 		};
 	}

--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -23,7 +23,6 @@ package haxelib.client;
 
 import haxe.display.Server.ConfigurePrintParams;
 import haxelib.VersionData.VersionDataHelper;
-import haxe.crypto.Md5;
 import haxe.iterators.ArrayIterator;
 
 import sys.FileSystem;
@@ -358,13 +357,12 @@ class Main {
 	function doRegister(name) {
 		final email = getArgument("Email");
 		final fullname = getArgument("Fullname");
-		final pass = getSecretArgument("Password");
-		final pass2 = getSecretArgument("Confirm");
-		if( pass != pass2 )
+		final password = getSecretArgument("Password");
+		final repeatedPassword = getSecretArgument("Confirm");
+		if (password != repeatedPassword )
 			throw "Password does not match";
-		final encodedPassword = Md5.encode(pass);
-		Connection.register(name, encodedPassword, email, fullname);
-		return encodedPassword;
+		Connection.register(name, password, email, fullname);
+		return password;
 	}
 
 	#if neko
@@ -400,13 +398,13 @@ class Main {
 	#end
 
 	function readPassword(user:String, prompt = "Password"):String {
-		var password = Md5.encode(getSecretArgument(prompt));
+		var password = getSecretArgument(prompt);
 		var attempts = 5;
 		while (!Connection.checkPassword(user, password)) {
 			Cli.print('Invalid password for $user');
 			if (--attempts == 0)
 				throw 'Failed to input correct password';
-			password = Md5.encode(getSecretArgument('$prompt ($attempts more attempt${attempts == 1 ? "" : "s"})'));
+			password = getSecretArgument('$prompt ($attempts more attempt${attempts == 1 ? "" : "s"})');
 		}
 		return password;
 	}


### PR DESCRIPTION
This changes the api version to 4.0, where hashing is done server side. For now, old clients are still allowed to use api version 3.0 and hash on the client. Later on, submission and registration can be disabled for api version 3.0 so that the migration can take place.

This makes it easier to deal with #314 (also see the thread regarding server side hashing).