### PR TITLE
Migrate server to haxe 4

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -344,7 +344,7 @@ aws-ndll:
     SAVE ARTIFACT /workspace/haxelib_global/aws-sdk-neko/*/ndll/Linux64/aws.ndll
 
 haxelib-server-builder:
-    FROM haxe:3.4
+    FROM haxe:4.3
 
     WORKDIR /workspace
     COPY lib/record-macros lib/record-macros

--- a/libs.hxml
+++ b/libs.hxml
@@ -1,6 +1,5 @@
--cmd curl -sSLk https://lib.haxe.org/files/3.0/tink_core-1,23,0.zip -o haxelib_global/tink_core.zip && neko run.n install --always --skip-dependencies haxelib_global/tink_core.zip
--cmd curl -sSLk https://lib.haxe.org/files/3.0/tink_core-1,0,0-rc,11.zip -o haxelib_global/tink_core.zip && neko run.n install --always --skip-dependencies haxelib_global/tink_core.zip
--cmd curl -sSLk https://lib.haxe.org/files/3.0/tink_macro-0,6,4.zip -o haxelib_global/tink_macro.zip && neko run.n install --always --skip-dependencies haxelib_global/tink_macro.zip
+-cmd curl -sSLk https://lib.haxe.org/files/3.0/tink_core-2,1,1.zip -o haxelib_global/tink_core.zip && neko run.n install --always --skip-dependencies haxelib_global/tink_core.zip
+-cmd curl -sSLk https://lib.haxe.org/files/3.0/tink_macro-1,0,0.zip -o haxelib_global/tink_macro.zip && neko run.n install --always --skip-dependencies haxelib_global/tink_macro.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/promhx-1,1,0.zip -o haxelib_global/promhx.zip && neko run.n install --always --skip-dependencies haxelib_global/promhx.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/asynctools-0,1,0.zip -o haxelib_global/asynctools.zip && neko run.n install --always --skip-dependencies haxelib_global/asynctools.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/buddy-2,8,1.zip -o haxelib_global/buddy.zip && neko run.n install --always --skip-dependencies haxelib_global/buddy.zip
@@ -20,11 +19,11 @@
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/mtwin-1,6,0.zip -o haxelib_global/mtwin.zip && neko run.n install --always --skip-dependencies haxelib_global/mtwin.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/PBKDF2-1,0,0.zip -o haxelib_global/PBKDF2.zip && neko run.n install --always --skip-dependencies haxelib_global/PBKDF2.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/tora-1,8,1.zip -o haxelib_global/tora.zip && neko run.n install --always --skip-dependencies haxelib_global/tora.zip
--cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-mvc-1,1,0.zip -o haxelib_global/ufront-mvc.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront-mvc.zip
+-cmd git clone https://github.com/ufront/ufront-mvc haxelib_global/ufront-mvc --depth=1 --single-branch && neko run.n dev ufront-mvc haxelib_global/ufront-mvc
+-cmd git clone https://github.com/ufront/ufront-ufadmin haxelib_global/ufront-ufadmin --depth=1 --single-branch && neko run.n dev ufront-ufadmin haxelib_global/ufront-ufadmin
+-cmd git clone https://github.com/ufront/ufront-easyauth haxelib_global/ufront-easyauth --depth=1 --single-branch && neko run.n dev ufront-easyauth haxelib_global/ufront-easyauth
+-cmd git clone https://github.com/ufront/ufront-mail haxelib_global/ufront-mail --depth=1 --single-branch && neko run.n dev ufront-mail haxelib_global/ufront-mail
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-orm-1,1,0.zip -o haxelib_global/ufront-orm.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront-orm.zip
--cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-easyauth-1,0,0.zip -o haxelib_global/ufront-easyauth.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront-easyauth.zip
--cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-mail-1,0,0-rc,4.zip -o haxelib_global/ufront-mail.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront-mail.zip
--cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-ufadmin-1,0,0-beta,14.zip -o haxelib_global/ufront-ufadmin.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront-ufadmin.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-uftasks-1,0,0-beta,15.zip -o haxelib_global/ufront-uftasks.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront-uftasks.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/ufront-2,0,0.zip -o haxelib_global/ufront.zip && neko run.n install --always --skip-dependencies haxelib_global/ufront.zip
 -cmd curl -sSLk https://lib.haxe.org/files/3.0/utest-1,9,6.zip -o haxelib_global/utest.zip && neko run.n install --always --skip-dependencies haxelib_global/utest.zip

--- a/server_api.hxml
+++ b/server_api.hxml
@@ -3,5 +3,7 @@
 -main haxelib.server.Repo
 -lib aws-sdk-neko
 -lib record-macros
+-cp hx3compat/std
+-cp hx4compat/std
 -dce no
 -D haxelib_api

--- a/server_legacy.hxml
+++ b/server_legacy.hxml
@@ -1,7 +1,7 @@
 server_each.hxml
 -neko www/legacy/index.n
 -main legacyhaxelib.Site
--lib hx2compat
+-lib record-macros
 -D haxelib_site
 -D haxelib_legacy
 -dce no

--- a/src/legacyhaxelib/SiteApi.hx
+++ b/src/legacyhaxelib/SiteApi.hx
@@ -47,10 +47,10 @@ class SiteApi {
 			versions.push({ name : v.name, comments : v.comments, date : v.date });
 		return {
 			name : p.name,
-			curversion : if( p.version == null ) null else p.version.name,
+			curversion : if( p.versionObj == null ) null else p.versionObj.name,
 			desc : p.description,
 			versions : versions,
-			owner : p.owner.name,
+			owner : p.ownerObj.name,
 			website : p.website,
 			license : p.license,
 			tags : Tag.manager.search({ project : p.id }).map(function(t) return t.tag),
@@ -98,7 +98,7 @@ class SiteApi {
 		if( p == null )
 			return;
 		for( d in Developer.manager.search({ project : p.id }) )
-			if( d.user.name == user )
+			if( d.userObj.name == user )
 				return;
 		throw "User '"+user+"' is not a developer of project '"+prj+"'";
 	}
@@ -146,18 +146,18 @@ class SiteApi {
 			p.website = infos.website;
 			p.license = infos.license;
 			p.downloads = 0;
-			p.owner = u;
+			p.ownerObj = u;
 			p.insert();
 			for( u in devs ) {
 				var d = new Developer();
-				d.user = u;
-				d.project = p;
+				d.userObj = u;
+				d.projectObj = p;
 				d.insert();
 			}
 			for( tag in tags ) {
 				var t = new Tag();
 				t.tag = tag;
-				t.project = p;
+				t.projectObj = p;
 				t.insert();
 			}
 		}
@@ -166,7 +166,7 @@ class SiteApi {
 		var pdevs = Developer.manager.search({ project : p.id });
 		var isdev = false;
 		for( d in pdevs )
-			if( d.user.id == u.id ) {
+			if( d.userObj.id == u.id ) {
 				isdev = true;
 				break;
 			}
@@ -178,7 +178,7 @@ class SiteApi {
 
 		// update public infos
 		if( infos.desc != p.description || p.website != infos.website || p.license != infos.license || pdevs.length != devs.length || tags.join(":") != curtags ) {
-			if( u.id != p.owner.id )
+			if( u.id != p.ownerObj.id )
 				throw "Only project owner can modify project infos";
 			p.description = infos.desc;
 			p.website = infos.website;
@@ -189,8 +189,8 @@ class SiteApi {
 					d.delete();
 				for( u in devs ) {
 					var d = new Developer();
-					d.user = u;
-					d.project = p;
+					d.userObj = u;
+					d.projectObj = p;
 					d.insert();
 				}
 			}
@@ -200,7 +200,7 @@ class SiteApi {
 				for( tag in tags ) {
 					var t = new Tag();
 					t.tag = tag;
-					t.project = p;
+					t.projectObj = p;
 					t.insert();
 				}
 			}
@@ -262,7 +262,7 @@ class SiteApi {
 
 		// add new version
 		var v = new Version();
-		v.project = p;
+		v.projectObj = p;
 		v.name = infos.version;
 		v.comments = infos.versionComments;
 		v.downloads = 0;
@@ -270,7 +270,7 @@ class SiteApi {
 		v.documentation = doc;
 		v.insert();
 
-		p.version = v;
+		p.versionObj = v;
 		p.update();
 		return "Version "+v.name+" (id#"+v.id+") added";
 	}


### PR DESCRIPTION
Use git versions of ufront libraries and update record macros with haxe 4.3 fix. This still requires some additional work to get the legacy server compiling.

Closes #565