### PR TITLE
Added ANSI coloring to `haxelib help` command

### DIFF
--- a/src/haxelib/client/ansi/Ansi.hx
+++ b/src/haxelib/client/ansi/Ansi.hx
@@ -1,0 +1,69 @@
+package haxelib.client.ansi;
+
+
+ /**
+  * https://en.wikipedia.org/wiki/ANSI_escape_code
+  * http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/c327.html
+  * http://ascii-table.com/ansi-escape-sequences.php
+  */
+ class Ansi {
+ 
+    /**
+     * ANSI escape sequence header
+     */
+    public static inline final ESC = "\x1B[";
+
+    inline
+    public static function reset(str:String):String
+       return str + ESC + "0m";
+ 
+ 
+    /**
+     * sets the given text attribute
+     */
+    inline
+    public static function attr(str:String, attr:AnsiTextAttribute):String
+       return ESC + (attr) + "m" + str;
+ 
+ 
+    /**
+     * set the text background color
+     *
+     * <pre><code>
+     * >>> Ansi.bg(RED) == "\x1B[41m"
+     * </code></pre>
+     */
+    inline
+    public static function bg(str: String, color:AnsiColor):String
+       return ESC + "4" + color + "m" + str;
+ 
+ 
+    /**
+     * Clears the screen and moves the cursor to the home position
+     */
+    inline
+    public static function clearScreen():String
+       return ESC + "2J";
+ 
+ 
+    /**
+     * Clear all characters from current position to the end of the line including the character at the current position
+     */
+    inline
+    public static function clearLine():String
+       return ESC + "K";
+ 
+ 
+    /**
+     * set the text foreground color
+     *
+     * <pre><code>
+     * >>> Ansi.fg(RED) == "\x1B[31m"
+     * </code></pre>
+     */
+    inline
+    public static function fg(str: String, color:AnsiColor):String
+       return ESC + "38;5;" + color + "m" + str;
+ 
+ }
+ 

--- a/src/haxelib/client/ansi/AnsiColor.hx
+++ b/src/haxelib/client/ansi/AnsiColor.hx
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: © Vegard IT GmbH (https://vegardit.com) and contributors
+ * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ package haxelib.client.ansi;
+
+#if (haxe_ver < 4.3) @:enum #else enum #end
+abstract AnsiColor(Int) {
+   final BLACK = 0;
+   final RED = 1;
+   final GREEN = 2;
+   final YELLOW = 3;
+   final BLUE = 4;
+   final MAGENTA = 5;
+   final CYAN = 6;
+   final WHITE = 7;
+   final DEFAULT = 9;
+   final ORANGE = 216;
+   final DARK_ORANGE = 215;
+   final ORANGE_BRIGHT = 208;
+}

--- a/src/haxelib/client/ansi/AnsiTextAttribute.hx
+++ b/src/haxelib/client/ansi/AnsiTextAttribute.hx
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: © Vegard IT GmbH (https://vegardit.com) and contributors
+ * SPDX-FileContributor: Sebastian Thomschke, Vegard IT GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package haxelib.client.ansi;
+
+/**
+ * https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes
+ */
+#if (haxe_ver < 4.3) @:enum #else enum #end
+abstract AnsiTextAttribute(Int) {
+
+   /**
+    * All colors/text-attributes off
+    */
+   final RESET = 0;
+
+   final INTENSITY_BOLD = 1;
+
+   /**
+    * Not widely supported.
+    */
+   final INTENSITY_FAINT = 2;
+
+   /**
+    * Not widely supported.
+    */
+   final ITALIC = 3;
+
+   final UNDERLINE_SINGLE = 4;
+
+   final BLINK_SLOW = 5;
+
+   /**
+    * Not widely supported.
+    */
+   final BLINK_FAST = 6;
+
+   final NEGATIVE = 7;
+
+   /**
+    * Not widely supported.
+    */
+   final HIDDEN = 8;
+
+   /**
+    * Not widely supported.
+    */
+   final STRIKETHROUGH = 9;
+
+   /**
+    * Not widely supported.
+    */
+   final UNDERLINE_DOUBLE = 21;
+
+   final INTENSITY_OFF = 22;
+
+   final ITALIC_OFF = 23;
+
+   final UNDERLINE_OFF = 24;
+
+   final BLINK_OFF = 25;
+
+   final NEGATIVE_OFF = 27;
+
+   final HIDDEN_OFF = 28;
+
+   final STRIKTHROUGH_OFF = 29;
+}


### PR DESCRIPTION
Will be looking for a bit more feedback on cleanup, but added ANSI coloring to the `haxelib help` command

<img width="733" alt="image" src="https://github.com/user-attachments/assets/d23079a4-d565-4210-90ef-d9f78d16acd6">

Things yet to implement
- [ ] Use the same environment variable that `hxcpp` uses to disable ansi codes for coloring
- [ ] I based the ansi related code off the `haxe-strings` implementation with a few changes, will poke around to make sure it's credited / licensed properly

ansi usage is to add
```
using haxelib.client.ansi.Ansi;
```

and then on any string you can add ANSI via one of the functions from `Ansi.hx` with the enums from `AnsiColor.hx` or `AnsiTextAttribute.hx`
`Cli.print("epic".fg(RED));`
will print
`epic` in red 
