### PR TITLE
Revert back to using DBCache

### DIFF
--- a/src/website/Server.hx
+++ b/src/website/Server.hx
@@ -32,8 +32,8 @@ class Server {
 		});
 		ufApp.injector.map( String, "documentationPath" ).toValue( neko.Web.getCwd()+"documentation-files/" );
 
-		ufApp.injector.map( UFCacheConnectionSync ).toClass( DummyCacheConnection );
-		ufApp.injector.map( UFCacheConnection ).toClass( DummyCacheConnection );
+		ufApp.injector.map( UFCacheConnectionSync ).toClass( DBCacheConnection );
+		ufApp.injector.map( UFCacheConnection ).toClass( DBCacheConnection );
 		// var cacheMiddleware = new RequestCacheMiddleware();
 		// ufApp.addRequestMiddleware( cacheMiddleware, true ).addResponseMiddleware( cacheMiddleware, true );
 


### PR DESCRIPTION
This fixes the (or at least many) memory usage issues of the haxelib server. The cache is meant to store the results of unzipping the libraries' zip archives. Without the cache, the server unzips a given library's .zip on every single request that requires any information about the library, including the overview page of a given library ( e.g. https://lib.haxe.org/p/hxcpp/).