### PR TITLE
Disallow library submissions containing `.git` folders

### DIFF
--- a/src/haxelib/Data.hx
+++ b/src/haxelib/Data.hx
@@ -194,6 +194,14 @@ typedef DefineDocumentation = {
 	var Unknown = 'Unknown';
 }
 
+typedef HaxelibFileEntry = {
+	@:requires( "Submission must not contain .git folder" =>
+		!(StringTools.startsWith(_, ".git/") ||
+		StringTools.contains(_, "/.git/"))
+	)
+	var fileName:String;
+};
+
 /** Class providing functions for working with project information. **/
 class Data {
 
@@ -330,6 +338,10 @@ class Data {
 
 		if (hasDefines && !definesFound) throw 'Json file `${infos.documentation.defines}` not found';
 		if (hasMetadata && !metadataFound) throw 'Json file `${infos.documentation.metadata}` not found';
+	}
+
+	public static function checkDisallowedFiles( zip : List<HaxelibFileEntry> ):Void {
+		Validator.validate(zip);
 	}
 
 	static function cleanDependencies(dependencies:Null<Dependencies>):Void {

--- a/src/haxelib/Data.hx
+++ b/src/haxelib/Data.hx
@@ -195,10 +195,9 @@ typedef DefineDocumentation = {
 }
 
 typedef HaxelibFileEntry = {
-	@:requires( "Submission must not contain .git folder" =>
-		!(StringTools.startsWith(_, ".git/") ||
-		StringTools.contains(_, "/.git/"))
-	)
+	@:requires("Submission must not contain .git folder" => !haxelib.Util.pathContainsDirectory(_, ".git"))
+	@:requires("Submission must not contain .svn folder" => !haxelib.Util.pathContainsDirectory(_, ".svn"))
+	@:requires("Submission must not contain .hg folder" => !haxelib.Util.pathContainsDirectory(_, ".hg"))
 	var fileName:String;
 };
 

--- a/src/haxelib/Util.hx
+++ b/src/haxelib/Util.hx
@@ -57,4 +57,8 @@ class Util {
 			return macro $v{version};
 		}
 	}
+
+	public static function pathContainsDirectory(path:String, directory:String) {
+		return path.startsWith('$directory/') || path.contains('/$directory/');
+	}
 }

--- a/src/haxelib/Validator.hx
+++ b/src/haxelib/Validator.hx
@@ -136,6 +136,14 @@ class Validator {
 							${doCheck(p, IARG)};
 					}
 
+				case TInst(_.get().module => 'haxe.ds.List', [p]):
+
+					macro @:pos(pos) {
+						${enforce('List')};
+						for ($IARG in $IARG)
+							${doCheck(p, IARG)};
+					}
+
 				case TAbstract(_.get() => { from: [ { t: t, field: null } ] }, _):
 
 					makeCheck(t);

--- a/src/haxelib/api/Connection.hx
+++ b/src/haxelib/api/Connection.hx
@@ -384,10 +384,14 @@ class Connection {
 		operation is aborted by default.
 
 		`logUploadStatus` can be passed in optionally to show progress during upload.
+
+		`runClientChecks` determines whether to run additional checks
+		before submitting to server, which will repeat these checks anyway.
 	**/
 	public static function submitLibrary(path:String, login:(Array<String>)->{name:String, password:String},
 		?overwrite:(version:SemVer)->Bool,
-		?logUploadStatus:(current:Int, total:Int) -> Void
+		?logUploadStatus:(current:Int, total:Int) -> Void,
+		runClientChecks = true
 	) {
 		var data:haxe.io.Bytes, zip:List<Entry>;
 		if (FileSystem.isDirectory(path)) {
@@ -401,9 +405,12 @@ class Connection {
 		}
 
 		final infos = Data.readDataFromZip(zip, CheckData);
-		Data.checkDisallowedFiles(zip);
-		Data.checkClassPath(zip, infos);
-		Data.checkDocumentation(zip, infos);
+
+		if (runClientChecks) {
+			Data.checkDisallowedFiles(zip);
+			Data.checkClassPath(zip, infos);
+			Data.checkDocumentation(zip, infos);
+		}
 
 		// ask user which contributor they are
 		final user = login(infos.contributors);

--- a/src/haxelib/api/Connection.hx
+++ b/src/haxelib/api/Connection.hx
@@ -401,6 +401,7 @@ class Connection {
 		}
 
 		final infos = Data.readDataFromZip(zip, CheckData);
+		Data.checkDisallowedFiles(zip);
 		Data.checkClassPath(zip, infos);
 		Data.checkDocumentation(zip, infos);
 

--- a/src/haxelib/server/Repo.hx
+++ b/src/haxelib/server/Repo.hx
@@ -191,6 +191,7 @@ class Repo implements SiteApi {
 				var infos = Data.readDataFromZip(zip,CheckData);
 				neko.Web.logMessage("processSubmit " + id + " readDataFromZip completed");
 
+				Data.checkDisallowedFiles(zip);
 				Data.checkClassPath(zip, infos);
 				Data.checkDocumentation(zip, infos);
 

--- a/test/IntegrationTests.hx
+++ b/test/IntegrationTests.hx
@@ -4,6 +4,8 @@ import sys.FileSystem;
 import sys.io.Process;
 import sys.io.File;
 
+import haxelib.api.Connection as HaxelibConnection;
+
 import haxe.unit.TestRunner;
 
 import haxelib.SemVer;
@@ -196,6 +198,8 @@ class IntegrationTests extends TestBase {
 		deleteDirectory(repo);
 		FileSystem.createDirectory(repo);
 		haxelibSetup(repo);
+
+		HaxelibConnection.remote = serverUrl;
 
 		Sys.setCwd(Path.join([projectRoot, "test"]));
 	}

--- a/test/Prepare.hx
+++ b/test/Prepare.hx
@@ -39,6 +39,15 @@ class Prepare {
 	static function main():Void {
 		var system = Sys.systemName();
 		var cwd = Sys.getCwd();
+
+		/*
+			Additional setup
+		*/
+		var gitFolder = "test/libraries/libWithGitFolder/.git";
+		if (!sys.FileSystem.exists(gitFolder)) {
+			FileSystem.createDirectory(gitFolder);
+		}
+
 		/*
 			(re)package the dummy libraries
 		*/

--- a/test/libraries/libWithGitFolder/haxelib.json
+++ b/test/libraries/libWithGitFolder/haxelib.json
@@ -1,0 +1,10 @@
+{
+	"name": "libWithGitFolder",
+	"url" : "http://example.org",
+	"license": "GPL",
+	"tags": [],
+	"description": "This project contains a .git folder",
+	"version": "0.0.1",
+	"releasenote": "Initial release, everything is working correctly",
+	"contributors": ["Bar"]
+}

--- a/test/tests/TestData.hx
+++ b/test/tests/TestData.hx
@@ -125,6 +125,52 @@ class TestData extends TestBase {
 		}
 	}
 
+	public function testCheckDisallowedFiles() {
+		final cases = [
+			{
+				zip: {
+					final list = new List();
+					list.add({ fileName: ".git/"});
+					list;
+				},
+				valid: false
+			},
+			{
+				zip: {
+					final list = new List();
+					list.add({fileName: "root/.git/"});
+					list;
+				},
+				valid: false
+			},
+			{
+				zip: {
+					final list = new List();
+					list.add({fileName: ".github/"});
+					list;
+				},
+				valid: true
+			},
+			{
+				zip: {
+					final list = new List();
+					list.add({fileName: "root/.github/"});
+					list;
+				},
+				valid: true
+			},
+		];
+
+		for (testCase in cases) {
+			try {
+				Data.checkDisallowedFiles(testCase.zip);
+				assertTrue(testCase.valid);
+			} catch (e:Dynamic) {
+				assertFalse(testCase.valid);
+			}
+		}
+	}
+
 	public function testReadDataWithDataCheck() {
 		assertFalse( readDataOkay("bad json") );
 

--- a/test/tests/TestData.hx
+++ b/test/tests/TestData.hx
@@ -146,6 +146,38 @@ class TestData extends TestBase {
 			{
 				zip: {
 					final list = new List();
+					list.add({fileName: ".svn/"});
+					list;
+				},
+				valid: false
+			},
+			{
+				zip: {
+					final list = new List();
+					list.add({fileName: "root/.svn/"});
+					list;
+				},
+				valid: false
+			},
+			{
+				zip: {
+					final list = new List();
+					list.add({fileName: ".hg/"});
+					list;
+				},
+				valid: false
+			},
+			{
+				zip: {
+					final list = new List();
+					list.add({fileName: "root/.hg/"});
+					list;
+				},
+				valid: false
+			},
+			{
+				zip: {
+					final list = new List();
 					list.add({fileName: ".github/"});
 					list;
 				},

--- a/test/tests/integration/TestSubmit.hx
+++ b/test/tests/integration/TestSubmit.hx
@@ -1,5 +1,7 @@
 package tests.integration;
 
+import haxelib.api.Connection;
+
 import tests.util.Vcs;
 
 class TestSubmit extends IntegrationTests {
@@ -142,7 +144,18 @@ class TestSubmit extends IntegrationTests {
 			bar.pw
 		]).result();
 		assertFail(r);
-		assertEquals("Error: Submission must not contain .git folder", r.err.trim());
+		assertEquals("Submission must not contain .git folder", r.err.trim().split(": ").pop());
+
+		// also test submission with client side checks disabled
+		try {
+			Connection.submitLibrary(Path.join([IntegrationTests.projectRoot, "test/libraries/libWithGitFolder.zip"]), _ -> {
+				password: bar.pw,
+				name: bar.user
+			}, false);
+			assertTrue(false);
+		} catch (e:String) {
+			assertEquals("Submission must not contain .git folder", e.split(": ").pop());
+		}
 
 		final r = haxelib(["search", "libWithGitFolder"]).result();
 		// did not get submitted

--- a/test/tests/integration/TestSubmit.hx
+++ b/test/tests/integration/TestSubmit.hx
@@ -131,4 +131,21 @@ class TestSubmit extends IntegrationTests {
 		// did not get submitted
 		assertFalse(r.out.indexOf("Bar") >= 0);
 	}
+
+	function testGitFolder() {
+		final r = haxelib(["register", bar.user, bar.email, bar.fullname, bar.pw, bar.pw]).result();
+		assertSuccess(r);
+
+		final r = haxelib([
+			"submit",
+			Path.join([IntegrationTests.projectRoot, "test/libraries/libWithGitFolder.zip"]),
+			bar.pw
+		]).result();
+		assertFail(r);
+		assertEquals("Error: Submission must not contain .git folder", r.err.trim());
+
+		final r = haxelib(["search", "libWithGitFolder"]).result();
+		// did not get submitted
+		assertFalse(r.out.indexOf("libWithGitFolder") >= 0);
+	}
 }


### PR DESCRIPTION
We already exclude hidden files when haxelib zips up a folder, but we had no checks for these in user made zip files.
This patch adds a server and client side check.