### PR TITLE
Update robots.txt

### DIFF
--- a/www/robots.txt
+++ b/www/robots.txt
@@ -7,19 +7,26 @@ Disallow: /p/*/*/raw-files/
 Disallow: /p/*/*/download/
 
 
-# https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/V3.2018.06.1119/robots.txt/robots.txt
+# https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/V4.2025.04.5162/robots.txt/robots.txt
+###################################################################
+# The Ultimate robots.txt Bot and User-Agent Blocker
+# Copyright:
+# https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker
+###################################################################
 
 ### Version Information #
 ###################################################
-### Version: V3.2018.06.1119
-### Updated: Thu Jun 28 16:29:29 SAST 2018
-### Bad Bot Count: 528
+### Version: V4.2025.04.5162
+### Updated: Fri Apr 18 10:08:12 UTC 2025
+### Bad Bot Count: 675
 ###################################################
 ### Version Information ##
 
 User-agent: *
 Disallow: /wp-admin/
 Allow: /wp-admin/admin-ajax.php
+User-agent: 01h4x.com
+Disallow:/
 User-agent: 360Spider
 Disallow:/
 User-agent: 404checker
@@ -28,19 +35,27 @@ User-agent: 404enemy
 Disallow:/
 User-agent: 80legs
 Disallow:/
+User-agent: ADmantX
+Disallow:/
+User-agent: AIBOT
+Disallow:/
+User-agent: ALittle Client
+Disallow:/
+User-agent: ASPSeek
+Disallow:/
 User-agent: Abonti
 Disallow:/
 User-agent: Aboundex
 Disallow:/
+User-agent: Aboundexbot
+Disallow:/
 User-agent: Acunetix
 Disallow:/
-User-agent: ADmantX
+User-agent: AdsTxtCrawlerTP
 Disallow:/
 User-agent: AfD-Verbotsverfahren
 Disallow:/
 User-agent: AhrefsBot
-Disallow:/
-User-agent: AIBOT
 Disallow:/
 User-agent: AiHitBot
 Disallow:/
@@ -48,35 +63,57 @@ User-agent: Aipbot
 Disallow:/
 User-agent: Alexibot
 Disallow:/
-User-agent: Alligator
-Disallow:/
 User-agent: AllSubmitter
+Disallow:/
+User-agent: Alligator
 Disallow:/
 User-agent: AlphaBot
 Disallow:/
 User-agent: Anarchie
 Disallow:/
+User-agent: Anarchy
+Disallow:/
+User-agent: Anarchy99
+Disallow:/
+User-agent: Ankit
+Disallow:/
+User-agent: Anthill
+Disallow:/
 User-agent: Apexoo
 Disallow:/
-User-agent: ASPSeek
+User-agent: Aspiegel
 Disallow:/
 User-agent: Asterias
 Disallow:/
+User-agent: Atomseobot
+Disallow:/
 User-agent: Attach
 Disallow:/
-User-agent: autoemailspider
+User-agent: AwarioBot
+Disallow:/
+User-agent: AwarioRssBot
+Disallow:/
+User-agent: AwarioSmartBot
+Disallow:/
+User-agent: BBBike
+Disallow:/
+User-agent: BDCbot
+Disallow:/
+User-agent: BDFetch
+Disallow:/
+User-agent: BLEXBot
 Disallow:/
 User-agent: BackDoorBot
-Disallow:/
-User-agent: Backlink-Ceck
-Disallow:/
-User-agent: backlink-check
-Disallow:/
-User-agent: BacklinkCrawler
 Disallow:/
 User-agent: BackStreet
 Disallow:/
 User-agent: BackWeb
+Disallow:/
+User-agent: Backlink-Ceck
+Disallow:/
+User-agent: BacklinkCrawler
+Disallow:/
+User-agent: BacklinksExtendedBot
 Disallow:/
 User-agent: Badass
 Disallow:/
@@ -88,25 +125,17 @@ User-agent: BatchFTP
 Disallow:/
 User-agent: Battleztar Bazinga
 Disallow:/
-User-agent: BBBike
-Disallow:/
-User-agent: BDCbot
-Disallow:/
-User-agent: BDFetch
-Disallow:/
 User-agent: BetaBot
 Disallow:/
 User-agent: Bigfoot
 Disallow:/
 User-agent: Bitacle
 Disallow:/
-User-agent: Blackboard
+User-agent: BlackWidow
 Disallow:/
 User-agent: Black Hole
 Disallow:/
-User-agent: BlackWidow
-Disallow:/
-User-agent: BLEXBot
+User-agent: Blackboard
 Disallow:/
 User-agent: Blow
 Disallow:/
@@ -122,7 +151,7 @@ User-agent: Brandprotect
 Disallow:/
 User-agent: Brandwatch
 Disallow:/
-User-agent: Bubing
+User-agent: Buck
 Disallow:/
 User-agent: Buddy
 Disallow:/
@@ -136,15 +165,27 @@ User-agent: BunnySlippers
 Disallow:/
 User-agent: BuzzSumo
 Disallow:/
-User-agent: Calculon
+User-agent: Bytespider
 Disallow:/
 User-agent: CATExplorador
 Disallow:/
-User-agent: CazoodleBot
-Disallow:/
 User-agent: CCBot
 Disallow:/
+User-agent: CODE87
+Disallow:/
+User-agent: CSHttp
+Disallow:/
+User-agent: Calculon
+Disallow:/
+User-agent: CazoodleBot
+Disallow:/
 User-agent: Cegbfeieh
+Disallow:/
+User-agent: CensysInspect
+Disallow:/
+User-agent: ChatGPT-User
+Disallow:/
+User-agent: CheTeam
 Disallow:/
 User-agent: CheeseBot
 Disallow:/
@@ -154,21 +195,21 @@ User-agent: ChinaClaw
 Disallow:/
 User-agent: Chlooe
 Disallow:/
+User-agent: Citoid
+Disallow:/
 User-agent: Claritybot
+Disallow:/
+User-agent: ClaudeBot
 Disallow:/
 User-agent: Cliqzbot
 Disallow:/
 User-agent: Cloud mapping
 Disallow:/
-User-agent: coccocbot-web
+User-agent: Cocolyzebot
 Disallow:/
 User-agent: Cogentbot
 Disallow:/
-User-agent: cognitiveseo
-Disallow:/
 User-agent: Collector
-Disallow:/
-User-agent: com.plumanalytics
 Disallow:/
 User-agent: Copier
 Disallow:/
@@ -180,27 +221,31 @@ User-agent: Cosmos
 Disallow:/
 User-agent: Craftbot
 Disallow:/
-User-agent: crawler4j
-Disallow:/
-User-agent: crawler.feedback
+User-agent: Crawling at Home Project
 Disallow:/
 User-agent: CrazyWebCrawler
 Disallow:/
 User-agent: Crescent
 Disallow:/
-User-agent: CSHttp
+User-agent: CrunchBot
 Disallow:/
 User-agent: Curious
 Disallow:/
 User-agent: Custo
 Disallow:/
-User-agent: DatabaseDriverMysqli
-Disallow:/
-User-agent: DataCha0s
+User-agent: CyotekWebCopy
 Disallow:/
 User-agent: DBLBot
 Disallow:/
-User-agent: demandbase-bot
+User-agent: DIIbot
+Disallow:/
+User-agent: DSearch
+Disallow:/
+User-agent: DTS Agent
+Disallow:/
+User-agent: DataCha0s
+Disallow:/
+User-agent: DatabaseDriverMysqli
 Disallow:/
 User-agent: Demon
 Disallow:/
@@ -212,8 +257,6 @@ User-agent: Digincore
 Disallow:/
 User-agent: DigitalPebble
 Disallow:/
-User-agent: DIIbot
-Disallow:/
 User-agent: Dirbuster
 Disallow:/
 User-agent: Disco
@@ -222,9 +265,15 @@ User-agent: Discobot
 Disallow:/
 User-agent: Discoverybot
 Disallow:/
+User-agent: Dispatch
+Disallow:/
 User-agent: DittoSpyder
 Disallow:/
+User-agent: DnBCrawler-Analytics
+Disallow:/
 User-agent: DnyzBot
+Disallow:/
+User-agent: DomCopBot
 Disallow:/
 User-agent: DomainAppender
 Disallow:/
@@ -234,6 +283,8 @@ User-agent: DomainSigmaCrawler
 Disallow:/
 User-agent: DomainStatsBot
 Disallow:/
+User-agent: Domains Project
+Disallow:/
 User-agent: Dotbot
 Disallow:/
 User-agent: Download Wonder
@@ -242,27 +293,21 @@ User-agent: Dragonfly
 Disallow:/
 User-agent: Drip
 Disallow:/
-User-agent: DTS Agent
-Disallow:/
-User-agent: EasyDL
-Disallow:/
-User-agent: Ebingbong
-Disallow:/
-User-agent: eCatch
-Disallow:/
 User-agent: ECCP/1.0
-Disallow:/
-User-agent: Ecxi
-Disallow:/
-User-agent: EirGrabber
 Disallow:/
 User-agent: EMail Siphon
 Disallow:/
 User-agent: EMail Wolf
 Disallow:/
-User-agent: EroCrawler
+User-agent: EasyDL
 Disallow:/
-User-agent: evc-batch
+User-agent: Ebingbong
+Disallow:/
+User-agent: Ecxi
+Disallow:/
+User-agent: EirGrabber
+Disallow:/
+User-agent: EroCrawler
 Disallow:/
 User-agent: Evil
 Disallow:/
@@ -284,9 +329,11 @@ User-agent: Ezooms
 Disallow:/
 User-agent: FDM
 Disallow:/
-User-agent: FemtosearchBot
-Disallow:/
 User-agent: FHscan
+Disallow:/
+User-agent: FacebookBot
+Disallow:/
+User-agent: FemtosearchBot
 Disallow:/
 User-agent: Fimap
 Disallow:/
@@ -302,7 +349,17 @@ User-agent: Freeuploader
 Disallow:/
 User-agent: FrontPage
 Disallow:/
+User-agent: Fuzz
+Disallow:/
+User-agent: FyberSpider
+Disallow:/
 User-agent: Fyrebot
+Disallow:/
+User-agent: G-i-g-a-b-o-t
+Disallow:/
+User-agent: GPTBot
+Disallow:/
+User-agent: GT::WWW
 Disallow:/
 User-agent: GalaxyBot
 Disallow:/
@@ -310,29 +367,25 @@ User-agent: Genieo
 Disallow:/
 User-agent: GermCrawler
 Disallow:/
-User-agent: Getintent
-Disallow:/
 User-agent: GetRight
 Disallow:/
 User-agent: GetWeb
 Disallow:/
-User-agent: Gigablast
+User-agent: Getintent
 Disallow:/
 User-agent: Gigabot
 Disallow:/
-User-agent: G-i-g-a-b-o-t
+User-agent: Go!Zilla
 Disallow:/
 User-agent: Go-Ahead-Got-It
 Disallow:/
-User-agent: Gotit
-Disallow:/
 User-agent: GoZilla
 Disallow:/
-User-agent: Go!Zilla
-Disallow:/
-User-agent: Grabber
+User-agent: Gotit
 Disallow:/
 User-agent: GrabNet
+Disallow:/
+User-agent: Grabber
 Disallow:/
 User-agent: Grafula
 Disallow:/
@@ -342,21 +395,7 @@ User-agent: GrapeshotCrawler
 Disallow:/
 User-agent: GridBot
 Disallow:/
-User-agent: GT::WWW
-Disallow:/
-User-agent: Haansoft
-Disallow:/
-User-agent: HaosouSpider
-Disallow:/
-User-agent: Harvest
-Disallow:/
-User-agent: Havij
-Disallow:/
 User-agent: HEADMasterSEO
-Disallow:/
-User-agent: Heritrix
-Disallow:/
-User-agent: Hloader
 Disallow:/
 User-agent: HMView
 Disallow:/
@@ -366,13 +405,31 @@ User-agent: HTTP::Lite
 Disallow:/
 User-agent: HTTrack
 Disallow:/
+User-agent: Haansoft
+Disallow:/
+User-agent: HaosouSpider
+Disallow:/
+User-agent: Harvest
+Disallow:/
+User-agent: Havij
+Disallow:/
+User-agent: Heritrix
+Disallow:/
+User-agent: Hloader
+Disallow:/
+User-agent: HonoluluBot
+Disallow:/
 User-agent: Humanlinks
 Disallow:/
 User-agent: HybridBot
 Disallow:/
-User-agent: Iblog
+User-agent: IDBTE4M
 Disallow:/
 User-agent: IDBot
+Disallow:/
+User-agent: IRLbot
+Disallow:/
+User-agent: Iblog
 Disallow:/
 User-agent: Id-search
 Disallow:/
@@ -382,6 +439,8 @@ User-agent: Image Fetch
 Disallow:/
 User-agent: Image Sucker
 Disallow:/
+User-agent: ImagesiftBot
+Disallow:/
 User-agent: IndeedBot
 Disallow:/
 User-agent: Indy Library
@@ -390,27 +449,27 @@ User-agent: InfoNaviRobot
 Disallow:/
 User-agent: InfoTekies
 Disallow:/
-User-agent: instabid
+User-agent: Information Security Team InfraSec Scanner
+Disallow:/
+User-agent: InfraSec Scanner
 Disallow:/
 User-agent: Intelliseek
 Disallow:/
 User-agent: InterGET
 Disallow:/
-User-agent: Internet Ninja
+User-agent: InternetMeasurement
 Disallow:/
 User-agent: InternetSeer
 Disallow:/
-User-agent: internetVista monitor
-Disallow:/
-User-agent: ips-agent
+User-agent: Internet Ninja
 Disallow:/
 User-agent: Iria
-Disallow:/
-User-agent: IRLbot
 Disallow:/
 User-agent: Iskanie
 Disallow:/
 User-agent: IstellaBot
+Disallow:/
+User-agent: JOC Web Spider
 Disallow:/
 User-agent: JamesBOT
 Disallow:/
@@ -420,9 +479,9 @@ User-agent: JennyBot
 Disallow:/
 User-agent: JetCar
 Disallow:/
-User-agent: JikeSpider
+User-agent: Jetty
 Disallow:/
-User-agent: JOC Web Spider
+User-agent: JikeSpider
 Disallow:/
 User-agent: Joomla
 Disallow:/
@@ -434,13 +493,23 @@ User-agent: Jyxobot
 Disallow:/
 User-agent: Kenjin Spider
 Disallow:/
+User-agent: Keybot Translation-Search-Machine
+Disallow:/
 User-agent: Keyword Density
 Disallow:/
+User-agent: Kinza
+Disallow:/
 User-agent: Kozmosbot
+Disallow:/
+User-agent: LNSpiderguy
+Disallow:/
+User-agent: LWP::Simple
 Disallow:/
 User-agent: Lanshanbot
 Disallow:/
 User-agent: Larbin
+Disallow:/
+User-agent: Leap
 Disallow:/
 User-agent: LeechFTP
 Disallow:/
@@ -454,21 +523,23 @@ User-agent: LibWeb
 Disallow:/
 User-agent: Libwhisker
 Disallow:/
+User-agent: LieBaoFast
+Disallow:/
 User-agent: Lightspeedsystems
 Disallow:/
 User-agent: Likse
 Disallow:/
-User-agent: Linkdexbot
+User-agent: LinkScan
+Disallow:/
+User-agent: LinkWalker
+Disallow:/
+User-agent: Linkbot
 Disallow:/
 User-agent: LinkextractorPro
 Disallow:/
 User-agent: LinkpadBot
 Disallow:/
-User-agent: LinkScan
-Disallow:/
 User-agent: LinksManager
-Disallow:/
-User-agent: LinkWalker
 Disallow:/
 User-agent: LinqiaMetadataDownloaderBot
 Disallow:/
@@ -478,81 +549,97 @@ User-agent: LinqiaScrapeBot
 Disallow:/
 User-agent: Lipperhey
 Disallow:/
+User-agent: Lipperhey Spider
+Disallow:/
 User-agent: Litemage_walker
 Disallow:/
 User-agent: Lmspider
 Disallow:/
-User-agent: LNSpiderguy
-Disallow:/
 User-agent: Ltx71
 Disallow:/
-User-agent: lwp-request
-Disallow:/
-User-agent: LWP::Simple
-Disallow:/
-User-agent: lwp-trivial
-Disallow:/
-User-agent: Magnet
-Disallow:/
-User-agent: Mag-Net
-Disallow:/
-User-agent: magpie-crawler
-Disallow:/
-User-agent: Mail.RU_Bot
-Disallow:/
-User-agent: Majestic12
-Disallow:/
-User-agent: MarkMonitor
-Disallow:/
-User-agent: MarkWatch
-Disallow:/
-User-agent: Masscan
-Disallow:/
-User-agent: Mass Downloader
-Disallow:/
-User-agent: Mata Hari
-Disallow:/
-User-agent: MauiBot
-Disallow:/
-User-agent: Meanpathbot
-Disallow:/
-User-agent: mediawords
-Disallow:/
-User-agent: MegaIndex.ru
-Disallow:/
-User-agent: Metauri
-Disallow:/
 User-agent: MFC_Tear_Sample
-Disallow:/
-User-agent: Microsoft Data Access
-Disallow:/
-User-agent: Microsoft URL Control
 Disallow:/
 User-agent: MIDown tool
 Disallow:/
 User-agent: MIIxpc
 Disallow:/
-User-agent: Mister PiX
-Disallow:/
 User-agent: MJ12bot
 Disallow:/
-User-agent: Mojeek
-Disallow:/
-User-agent: Morfeus Fucking Scanner
-Disallow:/
-User-agent: Mr.4x3
+User-agent: MQQBrowser
 Disallow:/
 User-agent: MSFrontPage
 Disallow:/
 User-agent: MSIECrawler
 Disallow:/
+User-agent: MTRobot
+Disallow:/
+User-agent: Mag-Net
+Disallow:/
+User-agent: Magnet
+Disallow:/
+User-agent: Mail.RU_Bot
+Disallow:/
+User-agent: Majestic-SEO
+Disallow:/
+User-agent: Majestic12
+Disallow:/
+User-agent: Majestic SEO
+Disallow:/
+User-agent: MarkMonitor
+Disallow:/
+User-agent: MarkWatch
+Disallow:/
+User-agent: Mass Downloader
+Disallow:/
+User-agent: Masscan
+Disallow:/
+User-agent: Mata Hari
+Disallow:/
+User-agent: MauiBot
+Disallow:/
+User-agent: Mb2345Browser
+Disallow:/
+User-agent: MeanPath Bot
+Disallow:/
+User-agent: Meanpathbot
+Disallow:/
+User-agent: Mediatoolkitbot
+Disallow:/
+User-agent: MegaIndex.ru
+Disallow:/
+User-agent: Metauri
+Disallow:/
+User-agent: MicroMessenger
+Disallow:/
+User-agent: Microsoft Data Access
+Disallow:/
+User-agent: Microsoft URL Control
+Disallow:/
+User-agent: Minefield
+Disallow:/
+User-agent: Mister PiX
+Disallow:/
+User-agent: Moblie Safari
+Disallow:/
+User-agent: Mojeek
+Disallow:/
+User-agent: Mojolicious
+Disallow:/
+User-agent: MolokaiBot
+Disallow:/
+User-agent: Morfeus Fucking Scanner
+Disallow:/
+User-agent: Mozlila
+Disallow:/
+User-agent: Mr.4x3
+Disallow:/
 User-agent: Msrabot
 Disallow:/
-User-agent: MS Web Services Client Protocol
-Disallow:/
-User-agent: muhstik-scan
-Disallow:/
 User-agent: Musobot
+Disallow:/
+User-agent: NICErsPRO
+Disallow:/
+User-agent: NPbot
 Disallow:/
 User-agent: Name Intelligence
 Disallow:/
@@ -568,29 +655,25 @@ User-agent: Nessus
 Disallow:/
 User-agent: NetAnts
 Disallow:/
-User-agent: Netcraft
-Disallow:/
-User-agent: netEstate NE Crawler
-Disallow:/
 User-agent: NetLyzer
 Disallow:/
 User-agent: NetMechanic
 Disallow:/
 User-agent: NetSpider
 Disallow:/
-User-agent: Nettrack
+User-agent: NetZIP
 Disallow:/
 User-agent: Net Vampire
 Disallow:/
-User-agent: Netvibes
+User-agent: Netcraft
 Disallow:/
-User-agent: NetZIP
+User-agent: Nettrack
+Disallow:/
+User-agent: Netvibes
 Disallow:/
 User-agent: NextGenSearchBot
 Disallow:/
 User-agent: Nibbler
-Disallow:/
-User-agent: NICErsPRO
 Disallow:/
 User-agent: Niki-bot
 Disallow:/
@@ -598,15 +681,15 @@ User-agent: Nikto
 Disallow:/
 User-agent: NimbleCrawler
 Disallow:/
+User-agent: Nimbostratus
+Disallow:/
 User-agent: Ninja
 Disallow:/
 User-agent: Nmap
 Disallow:/
-User-agent: NPbot
+User-agent: Nuclei
 Disallow:/
 User-agent: Nutch
-Disallow:/
-User-agent: oBot
 Disallow:/
 User-agent: Octopus
 Disallow:/
@@ -614,9 +697,13 @@ User-agent: Offline Explorer
 Disallow:/
 User-agent: Offline Navigator
 Disallow:/
-User-agent: Openfind
+User-agent: OnCrawl
 Disallow:/
 User-agent: OpenLinkProfiler
+Disallow:/
+User-agent: OpenVAS
+Disallow:/
+User-agent: Openfind
 Disallow:/
 User-agent: Openvas
 Disallow:/
@@ -628,15 +715,23 @@ User-agent: OutclicksBot
 Disallow:/
 User-agent: OutfoxBot
 Disallow:/
-User-agent: PageAnalyzer
+User-agent: PECL::HTTP
 Disallow:/
-User-agent: Page Analyzer
+User-agent: PHPCrawl
+Disallow:/
+User-agent: POE-Component-Client-HTTP
+Disallow:/
+User-agent: PageAnalyzer
 Disallow:/
 User-agent: PageGrabber
 Disallow:/
-User-agent: page scorer
-Disallow:/
 User-agent: PageScorer
+Disallow:/
+User-agent: PageThing.com
+Disallow:/
+User-agent: Page Analyzer
+Disallow:/
+User-agent: Pandalytics
 Disallow:/
 User-agent: Panscient
 Disallow:/
@@ -644,13 +739,11 @@ User-agent: Papa Foto
 Disallow:/
 User-agent: Pavuk
 Disallow:/
-User-agent: pcBrowser
-Disallow:/
-User-agent: PECL::HTTP
-Disallow:/
 User-agent: PeoplePal
 Disallow:/
-User-agent: PHPCrawl
+User-agent: Petalbot
+Disallow:/
+User-agent: Pi-Monster
 Disallow:/
 User-agent: Picscout
 Disallow:/
@@ -658,27 +751,27 @@ User-agent: Picsearch
 Disallow:/
 User-agent: PictureFinder
 Disallow:/
-User-agent: Pimonster
+User-agent: Piepmatz
 Disallow:/
-User-agent: Pi-Monster
+User-agent: Pimonster
 Disallow:/
 User-agent: Pixray
 Disallow:/
 User-agent: PleaseCrawl
 Disallow:/
-User-agent: plumanalytics
-Disallow:/
 User-agent: Pockey
-Disallow:/
-User-agent: POE-Component-Client-HTTP
-Disallow:/
-User-agent: Probethenet
 Disallow:/
 User-agent: ProPowerBot
 Disallow:/
 User-agent: ProWebWalker
 Disallow:/
+User-agent: Probethenet
+Disallow:/
+User-agent: Proximic
+Disallow:/
 User-agent: Psbot
+Disallow:/
+User-agent: Pu_iN
 Disallow:/
 User-agent: Pump
 Disallow:/
@@ -689,6 +782,10 @@ Disallow:/
 User-agent: QueryN Metasearch
 Disallow:/
 User-agent: Quick-Crawler
+Disallow:/
+User-agent: RSSingBot
+Disallow:/
+User-agent: Rainbot
 Disallow:/
 User-agent: RankActive
 Disallow:/
@@ -704,6 +801,10 @@ User-agent: Rankivabot
 Disallow:/
 User-agent: RankurBot
 Disallow:/
+User-agent: Re-re
+Disallow:/
+User-agent: ReGet
+Disallow:/
 User-agent: RealDownload
 Disallow:/
 User-agent: Reaper
@@ -714,8 +815,6 @@ User-agent: Recorder
 Disallow:/
 User-agent: RedesScrapy
 Disallow:/
-User-agent: ReGet
-Disallow:/
 User-agent: RepoMonkey
 Disallow:/
 User-agent: Ripper
@@ -724,15 +823,31 @@ User-agent: RocketCrawler
 Disallow:/
 User-agent: Rogerbot
 Disallow:/
-User-agent: SalesIntelligent
-Disallow:/
 User-agent: SBIder
+Disallow:/
+User-agent: SEOkicks
+Disallow:/
+User-agent: SEOkicks-Robot
+Disallow:/
+User-agent: SEOlyt
+Disallow:/
+User-agent: SEOlyticsCrawler
+Disallow:/
+User-agent: SEOprofiler
+Disallow:/
+User-agent: SEOstats
+Disallow:/
+User-agent: SISTRIX
+Disallow:/
+User-agent: SMTBot
+Disallow:/
+User-agent: SalesIntelligent
 Disallow:/
 User-agent: ScanAlert
 Disallow:/
 User-agent: Scanbot
 Disallow:/
-User-agent: scan.lol
+User-agent: ScoutJet
 Disallow:/
 User-agent: Scrapy
 Disallow:/
@@ -740,43 +855,53 @@ User-agent: Screaming
 Disallow:/
 User-agent: ScreenerBot
 Disallow:/
+User-agent: ScrepyBot
+Disallow:/
 User-agent: Searchestate
 Disallow:/
 User-agent: SearchmetricsBot
+Disallow:/
+User-agent: Seekport
+Disallow:/
+User-agent: SeekportBot
+Disallow:/
+User-agent: SemanticJuice
 Disallow:/
 User-agent: Semrush
 Disallow:/
 User-agent: SemrushBot
 Disallow:/
-User-agent: SEOkicks
+User-agent: SemrushBot-BA
 Disallow:/
-User-agent: SEOlyticsCrawler
+User-agent: SemrushBot-FT
+Disallow:/
+User-agent: SemrushBot-OCOB
+Disallow:/
+User-agent: SemrushBot-SI
+Disallow:/
+User-agent: SemrushBot-SWA
+Disallow:/
+User-agent: SentiBot
+Disallow:/
+User-agent: SenutoBot
+Disallow:/
+User-agent: SeoCherryBot
+Disallow:/
+User-agent: SeoSiteCheckup
+Disallow:/
+User-agent: SeobilityBot
 Disallow:/
 User-agent: Seomoz
-Disallow:/
-User-agent: SEOprofiler
-Disallow:/
-User-agent: seoscanners
-Disallow:/
-User-agent: SEOstats
-Disallow:/
-User-agent: sexsearcher
-Disallow:/
-User-agent: Seznam
-Disallow:/
-User-agent: SeznamBot
 Disallow:/
 User-agent: Shodan
 Disallow:/
 User-agent: Siphon
 Disallow:/
-User-agent: SISTRIX
+User-agent: SiteAuditBot
 Disallow:/
-User-agent: Sitebeam
+User-agent: SiteCheckerBotCrawler
 Disallow:/
 User-agent: SiteExplorer
-Disallow:/
-User-agent: Siteimprove
 Disallow:/
 User-agent: SiteLockSpider
 Disallow:/
@@ -786,15 +911,15 @@ User-agent: SiteSucker
 Disallow:/
 User-agent: Site Sucker
 Disallow:/
-User-agent: Sitevigil
+User-agent: Sitebeam
 Disallow:/
-User-agent: Slackbot-LinkExpanding
+User-agent: Siteimprove
+Disallow:/
+User-agent: Sitevigil
 Disallow:/
 User-agent: SlySearch
 Disallow:/
 User-agent: SmartDownload
-Disallow:/
-User-agent: SMTBot
 Disallow:/
 User-agent: Snake
 Disallow:/
@@ -803,6 +928,8 @@ Disallow:/
 User-agent: Snoopy
 Disallow:/
 User-agent: SocialRankIOBot
+Disallow:/
+User-agent: Sociscraper
 Disallow:/
 User-agent: Sogou web spider
 Disallow:/
@@ -820,7 +947,13 @@ User-agent: Spanner
 Disallow:/
 User-agent: Spbot
 Disallow:/
+User-agent: Spider_Bot
+Disallow:/
+User-agent: Spider_Bot/3.0
+Disallow:/
 User-agent: Spinn3r
+Disallow:/
+User-agent: SplitSignalBot
 Disallow:/
 User-agent: SputnikBot
 Disallow:/
@@ -850,15 +983,11 @@ User-agent: Suzuran
 Disallow:/
 User-agent: Swiftbot
 Disallow:/
-User-agent: sysscan
-Disallow:/
 User-agent: Szukacz
 Disallow:/
 User-agent: T0PHackTeam
 Disallow:/
 User-agent: T8Abot
-Disallow:/
-User-agent: tAkeOut
 Disallow:/
 User-agent: Teleport
 Disallow:/
@@ -870,11 +999,15 @@ User-agent: Telesphoreo
 Disallow:/
 User-agent: Telesphorep
 Disallow:/
-User-agent: The Intraformant
-Disallow:/
 User-agent: TheNomad
 Disallow:/
+User-agent: The Intraformant
+Disallow:/
+User-agent: Thumbor
+Disallow:/
 User-agent: TightTwatBot
+Disallow:/
+User-agent: TinyTestBot
 Disallow:/
 User-agent: Titan
 Disallow:/
@@ -882,13 +1015,11 @@ User-agent: Toata
 Disallow:/
 User-agent: Toweyabot
 Disallow:/
+User-agent: Tracemyfile
+Disallow:/
 User-agent: Trendiction
 Disallow:/
 User-agent: Trendictionbot
-Disallow:/
-User-agent: trendiction.com
-Disallow:/
-User-agent: trendiction.de
 Disallow:/
 User-agent: True_Robot
 Disallow:/
@@ -904,19 +1035,25 @@ User-agent: Twice
 Disallow:/
 User-agent: Typhoeus
 Disallow:/
-User-agent: UnisterBot
-Disallow:/
 User-agent: URLy.Warning
 Disallow:/
 User-agent: URLy Warning
+Disallow:/
+User-agent: UnisterBot
+Disallow:/
+User-agent: Upflow
+Disallow:/
+User-agent: V-BOT
+Disallow:/
+User-agent: VB Project
+Disallow:/
+User-agent: VCI
 Disallow:/
 User-agent: Vacuum
 Disallow:/
 User-agent: Vagabondo
 Disallow:/
-User-agent: VB Project
-Disallow:/
-User-agent: VCI
+User-agent: VelenPublicWebCrawler
 Disallow:/
 User-agent: VeriCiteCrawler
 Disallow:/
@@ -930,41 +1067,45 @@ User-agent: Voil
 Disallow:/
 User-agent: Voltron
 Disallow:/
-User-agent: Wallpapers/3.0
-Disallow:/
-User-agent: WallpapersHD
-Disallow:/
 User-agent: WASALive-Bot
 Disallow:/
 User-agent: WBSearchBot
 Disallow:/
-User-agent: Webalta
+User-agent: WEBDAV
+Disallow:/
+User-agent: WISENutbot
+Disallow:/
+User-agent: WPScan
+Disallow:/
+User-agent: WWW-Collector-E
+Disallow:/
+User-agent: WWW-Mechanize
+Disallow:/
+User-agent: WWW::Mechanize
+Disallow:/
+User-agent: WWWOFFLE
+Disallow:/
+User-agent: Wallpapers
+Disallow:/
+User-agent: Wallpapers/3.0
+Disallow:/
+User-agent: WallpapersHD
+Disallow:/
+User-agent: WeSEE
 Disallow:/
 User-agent: WebAuto
-Disallow:/
-User-agent: Web Auto
 Disallow:/
 User-agent: WebBandit
 Disallow:/
 User-agent: WebCollage
 Disallow:/
-User-agent: Web Collage
-Disallow:/
 User-agent: WebCopier
-Disallow:/
-User-agent: WEBDAV
 Disallow:/
 User-agent: WebEnhancer
 Disallow:/
-User-agent: Web Enhancer
-Disallow:/
 User-agent: WebFetch
 Disallow:/
-User-agent: Web Fetch
-Disallow:/
 User-agent: WebFuck
-Disallow:/
-User-agent: Web Fuck
 Disallow:/
 User-agent: WebGo IS
 Disallow:/
@@ -972,19 +1113,39 @@ User-agent: WebImageCollector
 Disallow:/
 User-agent: WebLeacher
 Disallow:/
-User-agent: WebmasterWorldForumBot
-Disallow:/
-User-agent: webmeup-crawler
-Disallow:/
 User-agent: WebPix
-Disallow:/
-User-agent: Web Pix
 Disallow:/
 User-agent: WebReaper
 Disallow:/
 User-agent: WebSauger
 Disallow:/
+User-agent: WebStripper
+Disallow:/
+User-agent: WebSucker
+Disallow:/
+User-agent: WebWhacker
+Disallow:/
+User-agent: WebZIP
+Disallow:/
+User-agent: Web Auto
+Disallow:/
+User-agent: Web Collage
+Disallow:/
+User-agent: Web Enhancer
+Disallow:/
+User-agent: Web Fetch
+Disallow:/
+User-agent: Web Fuck
+Disallow:/
+User-agent: Web Pix
+Disallow:/
 User-agent: Web Sauger
+Disallow:/
+User-agent: Web Sucker
+Disallow:/
+User-agent: Webalta
+Disallow:/
+User-agent: WebmasterWorldForumBot
 Disallow:/
 User-agent: Webshag
 Disallow:/
@@ -995,18 +1156,6 @@ Disallow:/
 User-agent: Website Quester
 Disallow:/
 User-agent: Webster
-Disallow:/
-User-agent: WebStripper
-Disallow:/
-User-agent: WebSucker
-Disallow:/
-User-agent: Web Sucker
-Disallow:/
-User-agent: WebWhacker
-Disallow:/
-User-agent: WebZIP
-Disallow:/
-User-agent: WeSEE
 Disallow:/
 User-agent: Whack
 Disallow:/
@@ -1022,8 +1171,6 @@ User-agent: WinHTTrack
 Disallow:/
 User-agent: WiseGuys Robot
 Disallow:/
-User-agent: WISENutbot
-Disallow:/
 User-agent: Wonderbot
 Disallow:/
 User-agent: Woobot
@@ -1032,27 +1179,13 @@ User-agent: Wotbox
 Disallow:/
 User-agent: Wprecon
 Disallow:/
-User-agent: WPScan
-Disallow:/
-User-agent: WWW-Collector-E
-Disallow:/
-User-agent: WWW-Mechanize
-Disallow:/
-User-agent: WWW::Mechanize
-Disallow:/
-User-agent: WWWOFFLE
-Disallow:/
-User-agent: x09Mozilla
-Disallow:/
-User-agent: x22Mozilla
+User-agent: Xaldon WebSpider
 Disallow:/
 User-agent: Xaldon_WebSpider
 Disallow:/
-User-agent: Xaldon WebSpider
-Disallow:/
 User-agent: Xenu
 Disallow:/
-User-agent: xpymep1.exe
+User-agent: YaK
 Disallow:/
 User-agent: YoudaoBot
 Disallow:/
@@ -1060,19 +1193,185 @@ User-agent: Zade
 Disallow:/
 User-agent: Zauba
 Disallow:/
-User-agent: zauba.io
-Disallow:/
 User-agent: Zermelo
 Disallow:/
 User-agent: Zeus
-Disallow:/
-User-agent: zgrab
 Disallow:/
 User-agent: Zitebot
 Disallow:/
 User-agent: ZmEu
 Disallow:/
+User-agent: ZoomBot
+Disallow:/
+User-agent: ZoominfoBot
+Disallow:/
 User-agent: ZumBot
 Disallow:/
 User-agent: ZyBorg
+Disallow:/
+User-agent: adscanner
+Disallow:/
+User-agent: anthropic-ai
+Disallow:/
+User-agent: archive.org_bot
+Disallow:/
+User-agent: arquivo-web-crawler
+Disallow:/
+User-agent: arquivo.pt
+Disallow:/
+User-agent: autoemailspider
+Disallow:/
+User-agent: awario.com
+Disallow:/
+User-agent: backlink-check
+Disallow:/
+User-agent: cah.io.community
+Disallow:/
+User-agent: check1.exe
+Disallow:/
+User-agent: clark-crawler
+Disallow:/
+User-agent: coccocbot
+Disallow:/
+User-agent: cognitiveseo
+Disallow:/
+User-agent: cohere-ai
+Disallow:/
+User-agent: com.plumanalytics
+Disallow:/
+User-agent: crawl.sogou.com
+Disallow:/
+User-agent: crawler.feedback
+Disallow:/
+User-agent: crawler4j
+Disallow:/
+User-agent: dataforseo.com
+Disallow:/
+User-agent: dataforseobot
+Disallow:/
+User-agent: demandbase-bot
+Disallow:/
+User-agent: domainsproject.org
+Disallow:/
+User-agent: eCatch
+Disallow:/
+User-agent: evc-batch
+Disallow:/
+User-agent: everyfeed-spider
+Disallow:/
+User-agent: facebookscraper
+Disallow:/
+User-agent: gopher
+Disallow:/
+User-agent: heritrix
+Disallow:/
+User-agent: imagesift.com
+Disallow:/
+User-agent: instabid
+Disallow:/
+User-agent: internetVista monitor
+Disallow:/
+User-agent: ips-agent
+Disallow:/
+User-agent: isitwp.com
+Disallow:/
+User-agent: iubenda-radar
+Disallow:/
+User-agent: linkdexbot
+Disallow:/
+User-agent: linkfluence
+Disallow:/
+User-agent: lwp-request
+Disallow:/
+User-agent: lwp-trivial
+Disallow:/
+User-agent: magpie-crawler
+Disallow:/
+User-agent: meanpathbot
+Disallow:/
+User-agent: mediawords
+Disallow:/
+User-agent: muhstik-scan
+Disallow:/
+User-agent: netEstate NE Crawler
+Disallow:/
+User-agent: oBot
+Disallow:/
+User-agent: omgili
+Disallow:/
+User-agent: openai
+Disallow:/
+User-agent: openai.com
+Disallow:/
+User-agent: page scorer
+Disallow:/
+User-agent: pcBrowser
+Disallow:/
+User-agent: plumanalytics
+Disallow:/
+User-agent: polaris version
+Disallow:/
+User-agent: probe-image-size
+Disallow:/
+User-agent: ripz
+Disallow:/
+User-agent: s1z.ru
+Disallow:/
+User-agent: satoristudio.net
+Disallow:/
+User-agent: scalaj-http
+Disallow:/
+User-agent: scan.lol
+Disallow:/
+User-agent: seobility
+Disallow:/
+User-agent: seocompany.store
+Disallow:/
+User-agent: seoscanners
+Disallow:/
+User-agent: seostar
+Disallow:/
+User-agent: serpstatbot
+Disallow:/
+User-agent: sexsearcher
+Disallow:/
+User-agent: sitechecker.pro
+Disallow:/
+User-agent: siteripz
+Disallow:/
+User-agent: sogouspider
+Disallow:/
+User-agent: sp_auditbot
+Disallow:/
+User-agent: spyfu
+Disallow:/
+User-agent: sysscan
+Disallow:/
+User-agent: tAkeOut
+Disallow:/
+User-agent: trendiction.com
+Disallow:/
+User-agent: trendiction.de
+Disallow:/
+User-agent: ubermetrics-technologies.com
+Disallow:/
+User-agent: voyagerx.com
+Disallow:/
+User-agent: webgains-bot
+Disallow:/
+User-agent: webmeup-crawler
+Disallow:/
+User-agent: webpros.com
+Disallow:/
+User-agent: webprosbot
+Disallow:/
+User-agent: x09Mozilla
+Disallow:/
+User-agent: x22Mozilla
+Disallow:/
+User-agent: xpymep1.exe
+Disallow:/
+User-agent: zauba.io
+Disallow:/
+User-agent: zgrab
 Disallow:/


### PR DESCRIPTION
The bot scraping landscape has changed a lot since 2018 and bots are overloading our server. This updates the robots.txt copy we use to the latest version from April 2025.

See:
https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/blob/V4.2025.04.5162/robots.txt/robots.txt

In particular, GPTBot is now blocked ;)