### PR TITLE
allow an arg for `version` command to display current version of a haxelib

### DIFF
--- a/src/haxelib/client/Main.hx
+++ b/src/haxelib/client/Main.hx
@@ -136,7 +136,13 @@ class Main {
 	}
 
 	function version() {
-		Cli.print(VERSION_LONG);
+		// Print haxelib version when no arguments are given
+		if (mainArgs.length == 0) {
+			Cli.print(VERSION_LONG);
+			return;
+		}
+
+		Cli.print(getRepository().getCurrentVersion(ProjectName.ofString(mainArgs[0])));
 	}
 
 	static function combineAliases(name:String, aliases:Array<String>):String {
@@ -211,7 +217,7 @@ class Main {
 			Config => create(config, 0),
 			Path => create(path, null),
 			LibPath => create(libpath, null),
-			Version => create(version, 0),
+			Version => create(version, 1),
 			Help => create(usage, 0),
 
 			#if !js


### PR DESCRIPTION
`haxelib version flixel` will output current selected version, ie: `git` if on git, or `5.0.0` if that's the current version

slightly different than `haxelib list flixel` which sorta merely "filters" the output, which then can include any / all libraries with "flixel" in its name