### PR TITLE
Add makefile for eval installation of haxelib on unix-like systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,24 +38,8 @@ haxelib_global
 
 .devcontainer/workspace
 
-
 # CMake
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-
-# VisualStudio
-*.vcxproj
-*.vcxproj.filters
-*.sln
-Win32
-haxelib.dir
+build
 
 # unit testing
 .unittest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+HAXE = haxe
+
+prefix = /usr/local
+bindir = $(prefix)/bin
+datadir = $(prefix)/share
+
+HAXELIB_OUTPUT = haxelib
+
+NEKOTOOLS = nekotools
+
+run.n:
+	$(HAXE) client.hxml
+
+ifeq ($(OS),Windows_NT)
+HAXELIB_OUTPUT = haxelib.exe
+
+$(HAXELIB_OUTPUT): run.n
+	$(NEKOTOOLS) boot run.n
+	mv run.exe $@
+
+else
+
+ifdef NEKO_LIB_PATH
+LDFLAGS = -Wl,-rpath,$(NEKO_LIB_PATH)
+endif
+
+LDLIBS = -lneko
+
+%.c: %.n
+	$(NEKOTOOLS) boot -c $<
+
+$(HAXELIB_OUTPUT): run.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $< -o $@ $(LDLIBS)
+
+endif
+
+install:
+	cp $(HAXELIB_OUTPUT) $(bindir)/haxelib
+
+uninstall:
+	rm $(bindir)/haxelib -rf
+
+clean:
+	rm run.n run.c $(HAXELIB_OUTPUT) -rf
+
+.DEFAULT_GOAL := $(HAXELIB_OUTPUT)
+
+.PHONY: install uninstall clean
+
+.SUFFIXES:
+

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(HAXELIB_OUTPUT): bin/haxelib_eval.hxb
 	echo $(HAXELIB_TARGET) > $(TARGET_CACHE_FILE)
 
 install:
-	mkdir $(datadir)/haxelib -p
+	mkdir -p $(datadir)/haxelib
 	mv bin/haxelib_eval.hxb $(datadir)/haxelib/
 
 	printf $(subst %hxb_file%,"$(datadir)/haxelib/haxelib_eval.hxb",$(SCRIPT)) > $(bindir)/haxelib
@@ -77,10 +77,10 @@ install:
 endif
 
 uninstall:
-	rm $(bindir)/haxelib $(datadir)/haxelib -rf
+	rm -rf $(bindir)/haxelib $(datadir)/haxelib
 
 clean:
-	rm run.n run.c $(HAXELIB_OUTPUT) bin/haxelib_eval.hxb $(TARGET_CACHE_FILE) -rf
+	rm -rf run.n run.c $(HAXELIB_OUTPUT) bin/haxelib_eval.hxb $(TARGET_CACHE_FILE)
 
 .DEFAULT_GOAL := $(HAXELIB_OUTPUT)
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,23 @@ datadir = $(prefix)/share
 
 HAXELIB_OUTPUT = haxelib
 
+
+TARGET_CACHE_FILE = bin/.target_cache
+HAXELIB_TARGET_CACHED = $(file < $(TARGET_CACHE_FILE))
+
+ifdef HAXELIB_TARGET
+ifneq ($(HAXELIB_TARGET), $(HAXELIB_TARGET_CACHED))
+# invalidate haxelib executable if target changed
+$(shell rm $(HAXELIB_OUTPUT))
+endif
+else ifneq ($(HAXELIB_TARGET_CACHED),)
+HAXELIB_TARGET = $(HAXELIB_TARGET_CACHED)
+else
+HAXELIB_TARGET = neko
+endif
+
+
+ifeq ($(HAXELIB_TARGET),neko)
 NEKOTOOLS = nekotools
 
 run.n:
@@ -17,6 +34,7 @@ HAXELIB_OUTPUT = haxelib.exe
 $(HAXELIB_OUTPUT): run.n
 	$(NEKOTOOLS) boot run.n
 	mv run.exe $@
+	echo $(HAXELIB_TARGET) > $(TARGET_CACHE_FILE)
 
 else
 
@@ -31,17 +49,38 @@ LDLIBS = -lneko
 
 $(HAXELIB_OUTPUT): run.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $< -o $@ $(LDLIBS)
+	echo $(HAXELIB_TARGET) > $(TARGET_CACHE_FILE)
 
 endif
 
 install:
 	cp $(HAXELIB_OUTPUT) $(bindir)/haxelib
+endif
+
+ifeq ($(HAXELIB_TARGET),eval)
+
+bin/haxelib_eval.hxb:
+	$(HAXE) client_eval_hxb.hxml
+
+SCRIPT = "\#!/bin/sh\nhaxe --hxb-lib %hxb_file% --run haxelib.client.Main \"\$$@\"\n"
+
+$(HAXELIB_OUTPUT): bin/haxelib_eval.hxb
+	printf $(subst %hxb_file%,\"$(CURDIR)/bin/haxelib_eval.hxb\",$(SCRIPT)) > $@
+	echo $(HAXELIB_TARGET) > $(TARGET_CACHE_FILE)
+
+install:
+	mkdir $(datadir)/haxelib -p
+	mv bin/haxelib_eval.hxb $(datadir)/haxelib/
+
+	printf $(subst %hxb_file%,"$(datadir)/haxelib/haxelib_eval.hxb",$(SCRIPT)) > $(bindir)/haxelib
+
+endif
 
 uninstall:
-	rm $(bindir)/haxelib -rf
+	rm $(bindir)/haxelib $(datadir)/haxelib -rf
 
 clean:
-	rm run.n run.c $(HAXELIB_OUTPUT) -rf
+	rm run.n run.c $(HAXELIB_OUTPUT) bin/haxelib_eval.hxb $(TARGET_CACHE_FILE) -rf
 
 .DEFAULT_GOAL := $(HAXELIB_OUTPUT)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Build files:
 * package.hxml: Package the client as package.zip for submitting to the lib.haxe.org as [haxelib](https://lib.haxe.org/p/haxelib/).
 * prepare_tests.hxml: Package the test libs.
 * ci.hxml: Used by our CIs, TravisCI and AppVeyor.
+* Makefile: Used to build and install haxelib on Unix like systems.
 
 Folders:
 

--- a/client_eval_hxb.hxml
+++ b/client_eval_hxb.hxml
@@ -1,0 +1,4 @@
+each.hxml
+--interp
+haxelib.client.Main
+--hxb bin/haxelib_eval.hxb


### PR DESCRIPTION
This adds a `Makefile` to the root of the repo. As well as building and installing a neko binary of haxelib, it also allows installing haxelib as an `sh` script that runs haxelib on `haxe` eval. The target can be set using `make HAXELIB_TARGET=eval`.

This should allow running haxelib on a system with no neko installation.

Also, since `Makefile` is now in the root of the repo, cmake must now generate its output in `build` to avoid overwriting it.